### PR TITLE
Converted the initializer to object initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 /node_modules
+.idea
+

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const pluralize = require('pluralize')
+const _ = require('lodash')
 const Promise = require('es6-promise').Promise
 const deserialize = require('./middleware/json-api/_deserialize')
 const serialize = require('./middleware/json-api/_serialize')
@@ -36,12 +37,31 @@ let jsonApiMiddleware = [
 
 class JsonApi {
 
-  constructor(apiUrl, middleware = jsonApiMiddleware) {
-    this._originalMiddleware = middleware.slice(0)
-    this.middleware = middleware.slice(0)
+  constructor (options = {}) {
+    if (!(arguments.length == 2 && _.isString(arguments[0]) && _.isArray(arguments[1])) && !(arguments.length === 1 && (_.isPlainObject(arguments[0]) || _.isString(arguments[0])))) {
+      throw new Error("Invalid argument, initialize Devour with an object.")
+    }
+
+    let defaults = {
+      middleware: jsonApiMiddleware
+    }
+
+    if (arguments.length === 2 || (arguments.length === 1 && _.isString(arguments[0]))) {
+      defaults.apiUrl = arguments[0]
+      if (arguments.length === 2) {
+        defaults.middleware = arguments[1]
+      }
+      console.error('Constructor (apiUrl, middleware) has been deprecated, initialize Devour with an object.')
+    }
+
+    options = _.assign(defaults, options)
+    let middleware = options.middleware
+
+    this._originalMiddleware = options.middleware.slice(0)
+    this.middleware = options.middleware.slice(0)
     this.headers = {}
     this.axios = axios
-    this.apiUrl = apiUrl
+    this.apiUrl = options.apiUrl
     this.models = {}
     this.deserialize = deserialize
     this.serialize = serialize

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "axios": "^0.11.0",
+    "babel-register": "^6.8.0",
     "es6-promise": "^3.1.2",
     "lodash": "^4.11.2",
     "pluralize": "^1.2.1",

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -6,7 +6,29 @@ describe('JsonApi', ()=> {
 
   var jsonApi = null
   beforeEach(()=> {
+    jsonApi = new JsonApi({apiUrl:'http://myapi.com'})
+  })
+
+  it('should allow both object and deprecated constructors to be used', ()=> {
+    let jsonApi
     jsonApi = new JsonApi('http://myapi.com')
+    expect(jsonApi).to.be.a(JsonApi)
+    jsonApi = new JsonApi('http://myapi.com', [])
+    expect(jsonApi).to.be.a(JsonApi)
+    jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
+    expect(jsonApi).to.be.a(JsonApi)
+  })
+
+  it.skip('should throw Exception if the constructor does not receive proper arguments', ()=> {
+
+    expect(function () {
+      throw new Error('boom!')
+    }).toThrow(/boom/)
+
+    expect(function(){
+      new JsonApi()
+    }).to.throw(Error)
+
   })
 
   it('should set the apiUrl during setup', ()=> {

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -7,7 +7,7 @@ describe('deserialize', ()=> {
 
   var jsonApi = null
   before(()=> {
-    jsonApi = new JsonApi('http://myapi.com')
+    jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
   })
 
   it('should deserialize single resource items', ()=> {

--- a/test/api/serialize-test.js
+++ b/test/api/serialize-test.js
@@ -7,7 +7,7 @@ describe('serialize', ()=> {
 
   var jsonApi = null
   beforeEach(()=> {
-    jsonApi = new JsonApi('http://myapi.com')
+    jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
   })
 
   it('should serialize resource items', ()=> {


### PR DESCRIPTION
## Priority
No

## Screenshot
<img width="1259" alt="screen shot 2016-05-05 at 11 26 52 pm" src="https://cloud.githubusercontent.com/assets/1641464/15063535/fcb45f4a-1318-11e6-97c1-df438fdbb908.png">


## What Changed & Why
Initializer now takes an object instead of list of arguments, this allows better extendability. See issue #15 

## Testing
`npm test`

## Bug/Ticket Tracker
See #15

## Documentation
See README.MD

## In Progress/Follow Up
https://github.com/twg/devour/blob/feature/hash-initializers/test/api/api-test.js#L22-L32 ES6 + Babel is not passing this test for some reason

Also, general consensus on using lodash as an utility package?

## Legal/Security/Privacy
N/A

## Third-Party
N/A

## People
@Emerson @derek-watson 