### PR TITLE
Feature/builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 /node_modules
+coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Devour takes an object as the initializer. The following options are available:
 
 **middleware**: An array of middleware to use. See below
 
+**logger**: A boolean to enable or disable the logger. (Default: true)
+
+**resetBuilderOnCall**: A boolean to clear the builder stack after a `.get`, `.post`, `.patch`, `.destroy` call. (Default: true)
 
 ### Relationships
 
@@ -155,4 +158,21 @@ jsonApi.headers['my-auth-token'] = 'xxxxx-xxxxx'
 jsonApi.middleware = [{...}, {...}, {...}]
 // Change the apiUrl
 jsonApi.apiUrl = 'http://api.yoursite.com'
+```
+
+### URL Builder
+
+JSON API Specs allows nested URLs to be used to define a resource. For example, `/authors/1/posts` may define posts from author with ID 1.
+
+The builder pattern allows arbitrary nested URL construction by chaining `.one(model, id)` and `.all(model)` and append an action, one of: `.get`, `.post`, `.patch` and `.destroy`
+
+For example:
+
+```js
+let jsonApi = new JsonApi({apiUrl: 'http://api.yoursite.com'})
+jsonApi.define('author', {name: ''})
+jsonApi.define('post', {title: ''})
+
+jsonApi.one('author', 1).all('post').get() // GET http://api.yoursite.com/authors/1/posts
+jsonApi.one('author', 1).all('post').post({title:'title'}) // POST http://api.yoursite.com/authors/1/posts
 ```

--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ class JsonApi {
 
     let defaults = {
       middleware: jsonApiMiddleware,
-      logger: true
+      logger: true,
+      resetBuilderOnCall: true
     }
 
     let deprecatedConstructos = (args) => {
@@ -71,6 +72,7 @@ class JsonApi {
     this.deserialize = deserialize
     this.serialize = serialize
     this.builderStack = []
+    this.resetBuilderOnCall = !!options.resetBuilderOnCall
     this.logger = Minilog('devour')
     options.logger ? Minilog.enable() : MiniLog.disable()
 
@@ -113,6 +115,11 @@ class JsonApi {
       data: {},
       params: params
     }
+
+    if (this.resetBuilderOnCall) {
+      this.resetBuilder()
+    }
+
     return this.runMiddleware(req)
   }
 
@@ -125,6 +132,11 @@ class JsonApi {
       model: lastRequest.get('model').value(),
       data: payload
     }
+
+    if (this.resetBuilderOnCall) {
+      this.resetBuilder()
+    }
+
     return this.runMiddleware(req)
   }
 
@@ -137,8 +149,12 @@ class JsonApi {
       model: lastRequest.get('model').value(),
       data: payload
     }
-    return this.runMiddleware(req)
 
+    if (this.resetBuilderOnCall) {
+      this.resetBuilder()
+    }
+
+    return this.runMiddleware(req)
   }
 
   destroy () {
@@ -150,6 +166,11 @@ class JsonApi {
       model: lastRequest.get('model').value(),
       data: {}
     }
+
+    if (this.resetBuilderOnCall) {
+      this.resetBuilder()
+    }
+
     return this.runMiddleware(req)
   }
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ class JsonApi {
     }
 
     let defaults = {
-      middleware: jsonApiMiddleware
+      middleware: jsonApiMiddleware,
+      logger: true
     }
 
     if (arguments.length === 2 || (arguments.length === 1 && _.isString(arguments[0]))) {
@@ -68,6 +69,9 @@ class JsonApi {
     this.serialize = serialize
     this.builderStack = []
     this.logger = Minilog('devour')
+
+    options.logger ? Minilog.enable() : MiniLog.disable()
+
   }
 
   enableLogging(enabled = true){
@@ -107,16 +111,41 @@ class JsonApi {
   }
 
   post (payload) {
-    console.log(_.chain(this.builderStack).last().get('model').value())
+    let lastRequest = _.chain(this.builderStack).last()
+
     let req = {
       method: 'POST',
       url: this.urlFor(),
-      model: _.chain(this.builderStack).last().get('model').value(),
+      model: lastRequest.get('model').value(),
       data: payload
     }
     return this.runMiddleware(req)
   }
 
+  patch (payload) {
+    let lastRequest = _.chain(this.builderStack).last()
+
+    let req = {
+      method: 'PATCH',
+      url: this.urlFor(),
+      model: lastRequest.get('model').value(),
+      data: payload
+    }
+    return this.runMiddleware(req)
+
+  }
+
+  destroy () {
+    let lastRequest = _.chain(this.builderStack).last()
+
+    let req = {
+      method: 'DELETE',
+      url: this.urlFor(),
+      model: lastRequest.get('model').value(),
+      data: {}
+    }
+    return this.runMiddleware(req)
+  }
 
   insertMiddlewareBefore(middlewareName, newMiddleware) {
     this.insertMiddleware(middlewareName, 'before', newMiddleware)

--- a/index.js
+++ b/index.js
@@ -48,12 +48,15 @@ class JsonApi {
       logger: true
     }
 
-    if (arguments.length === 2 || (arguments.length === 1 && _.isString(arguments[0]))) {
+    let deprecatedConstructos = (args) => {
+      return (args.length === 2 || (args.length === 1 && _.isString(args[0])))
+    }
+
+    if (deprecatedConstructos(arguments)) {
       defaults.apiUrl = arguments[0]
       if (arguments.length === 2) {
         defaults.middleware = arguments[1]
       }
-      console.error('Constructor (apiUrl, middleware) has been deprecated, initialize Devour with an object.')
     }
 
     options = _.assign(defaults, options)
@@ -69,8 +72,11 @@ class JsonApi {
     this.serialize = serialize
     this.builderStack = []
     this.logger = Minilog('devour')
-
     options.logger ? Minilog.enable() : MiniLog.disable()
+
+    if (deprecatedConstructos(arguments)) {
+      this.logger.warn('Constructor (apiUrl, middleware) has been deprecated, initialize Devour with an object.')
+    }
 
   }
 

--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
     "babel-core": "^6.7.7",
     "babel-preset-es2015": "^6.6.0",
     "expect.js": "^0.3.1",
+    "istanbul": "1.0.0-alpha.2",
     "mocha": "^2.4.5"
   },
   "dependencies": {
     "axios": "^0.11.0",
     "es6-promise": "^3.1.2",
     "lodash": "^4.11.2",
+    "minilog": "^3.0.0",
     "pluralize": "^1.2.1",
     "qs": "^6.1.0"
   }

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -9,6 +9,10 @@ describe('JsonApi', ()=> {
     jsonApi = new JsonApi({apiUrl:'http://myapi.com'})
   })
 
+  afterEach(()=>{
+    jsonApi.resetBuilder()
+  })
+
   it('should allow both object and deprecated constructors to be used', ()=> {
     let jsonApi
     jsonApi = new JsonApi('http://myapi.com')
@@ -61,10 +65,6 @@ describe('JsonApi', ()=> {
       new JsonApi()
     }).to.throw(Error)
 
-  })
-
-  afterEach(()=>{
-    jsonApi.resetBuilder()
   })
 
   it('should allow urlFor to be called with various options', () => {
@@ -130,42 +130,83 @@ describe('JsonApi', ()=> {
     }).catch(err => console.log(err))
   })
 
+  //{ method: 'GET', url: 'http://myapi.com/', data: {}, params: {} }
   it('should allow builders to be called with get', (done)=> {
-    mockResponse(jsonApi, {
-      data: {
-        data: [
-          {
-            id: '1',
-            type: 'foo',
-            attributes: {
-              title: 'foo 1'
-            }
-          },
-          {
-            id: '2',
-            type: 'foo',
-            attributes: {
-              title: 'foo 2'
-            }
-          }
-        ]
+    let inspectorMiddleware = {
+      name: 'inspector-middleware',
+      req: (payload)=> {
+        expect(payload.req.method).to.be.eql('GET')
+        expect(payload.req.url).to.be.eql('http://myapi.com/')
+        return {}
       }
-    })
+    }
+
+    jsonApi.middleware = [inspectorMiddleware]
 
     jsonApi.define('foo', {
       title: ''
     })
 
-    jsonApi.get().then((foos)=> {
-      expect(foos[0].id).to.eql('1')
-      expect(foos[0].title).to.eql('foo 1')
-      expect(foos[1].id).to.eql('2')
-      expect(foos[1].title).to.eql('foo 2')
-      done()
-    }).catch(err => console.log(err))
+    jsonApi.get().then(()=>done()).catch(()=>done())
   })
 
-  it.skip('should allow builders to be called with post', ()=> {
+  it('should allow builders to be called with post', (done)=> {
+    let inspectorMiddleware = {
+      name: 'inspector-middleware',
+      req: (payload)=> {
+        expect(payload.req.method).to.be.eql('POST')
+        expect(payload.req.url).to.be.eql('http://myapi.com/foos')
+        expect(payload.req.data).to.be.eql({title: 'foo'})
+        return {}
+      }
+    }
+
+    jsonApi.middleware = [inspectorMiddleware]
+
+    jsonApi.define('foo', {
+      title: ''
+    })
+
+    jsonApi.all('foo').post({title: 'foo'}).then(()=>done()).catch(()=>done())
+  })
+
+  it('should allow builders to be called with patch', (done)=> {
+    let inspectorMiddleware = {
+      name: 'inspector-middleware',
+      req: (payload)=> {
+        expect(payload.req.method).to.be.eql('PATCH')
+        expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
+        expect(payload.req.data).to.be.eql({title: 'bar'})
+        return {}
+      }
+    }
+
+    jsonApi.middleware = [inspectorMiddleware]
+
+    jsonApi.define('foo', {
+      title: ''
+    })
+
+    jsonApi.one('foo', 1).patch({title: 'bar'}).then(()=>done()).catch(()=>done())
+  })
+
+  it('should allow builders to be called with destroy', (done)=> {
+    let inspectorMiddleware = {
+      name: 'inspector-middleware',
+      req: (payload)=> {
+        expect(payload.req.method).to.be.eql('DELETE')
+        expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
+        return {}
+      }
+    }
+
+    jsonApi.middleware = [inspectorMiddleware]
+
+    jsonApi.define('foo', {
+      title: ''
+    })
+
+    jsonApi.one('foo', 1).destroy().then(()=>done()).catch(()=>done())
   })
 
   it('should set the apiUrl during setup', ()=> {
@@ -271,7 +312,7 @@ describe('JsonApi', ()=> {
           id: '1',
           type: 'products',
           attributes: {
-            'title': 'Some Title'
+            title: 'Some Title'
           }
         }
       }
@@ -294,14 +335,14 @@ describe('JsonApi', ()=> {
             id: '1',
             type: 'products',
             attributes: {
-              'title': 'Some Title'
+              title: 'Some Title'
             }
           },
           {
             id: '2',
             type: 'products',
             attributes: {
-              'title': 'Another Title'
+              title: 'Another Title'
             }
           }
         ]
@@ -319,7 +360,24 @@ describe('JsonApi', ()=> {
     }).catch(err => console.log(err))
   })
 
-  it.skip('should make basic create call', ()=> {
+  it('should make basic create call', ()=> {
+    let inspectorMiddleware = {
+      name: 'inspector-middleware',
+      req: (payload)=> {
+        expect(payload.req.method).to.be.eql('POST')
+        expect(payload.req.url).to.be.eql('http://myapi.com/foos')
+        expect(payload.req.data).to.be.eql({title: 'foo'})
+        return {}
+      }
+    }
+
+    jsonApi.middleware = [inspectorMiddleware]
+
+    jsonApi.define('foo', {
+      title: ''
+    })
+
+    jsonApi.create('foo', {title: 'foo'}).then(()=>done()).catch(()=>done())
   })
 
   it('should include meta information on response objects', (done)=> {
@@ -332,7 +390,7 @@ describe('JsonApi', ()=> {
           id: '1',
           type: 'products',
           attributes: {
-            'title': 'Some Title'
+            title: 'Some Title'
           }
         }]
       }

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -361,6 +361,22 @@ describe('JsonApi', ()=> {
       jsonApi.get().then(()=>done()).catch(()=>done())
     })
 
+    it('should allow builders to be called with get with query params', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('GET')
+          expect(payload.req.url).to.be.eql('http://myapi.com/')
+          expect(payload.req.params).to.be.eql({page: {number: 2}})
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.get({page: {number: 2}}).then(()=>done()).catch(()=>done())
+    })
+
     it('should allow builders to be called with get on all', (done)=> {
       let inspectorMiddleware = {
         name: 'inspector-middleware',

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -6,404 +6,490 @@ describe('JsonApi', ()=> {
 
   var jsonApi = null
   beforeEach(()=> {
-    jsonApi = new JsonApi({apiUrl:'http://myapi.com'})
-  })
-
-  afterEach(()=>{
-    jsonApi.resetBuilder()
-  })
-
-  it('should allow both object and deprecated constructors to be used', ()=> {
-    let jsonApi
-    jsonApi = new JsonApi('http://myapi.com')
-    expect(jsonApi).to.be.a(JsonApi)
-    jsonApi = new JsonApi('http://myapi.com', [])
-    expect(jsonApi).to.be.a(JsonApi)
     jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
-    expect(jsonApi).to.be.a(JsonApi)
   })
 
-  it('should allow apiUrl to be set via the initializer object', ()=> {
-    let jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
-    expect(jsonApi.apiUrl).to.eql('http://myapi.com')
-  })
-
-  it('should allow middleware to be set via the initializer object', ()=> {
-    let middleware = [
-      {
-        name: 'm1',
-        req: function(req) {
-          return req
-        },
-        res: function(res) {
-          return res
-        }
-      },
-      {
-        name: 'm2',
-        req: function(req) {
-          return req
-        },
-        res: function(res) {
-          return res
-        }
-      }
-    ]
-
-    let jsonApi = new JsonApi({apiUrl: 'http://myapi.com', middleware: middleware})
-    expect(jsonApi.middleware).to.eql(middleware)
-    expect(jsonApi.apiUrl).to.eql('http://myapi.com')
-  })
-
-  it.skip('should throw Exception if the constructor does not receive proper arguments', ()=> {
-
-    expect(function () {
-      throw new Error('boom!')
-    }).toThrow(/boom/)
-
-    expect(function(){
-      new JsonApi()
-    }).to.throw(Error)
-
-  })
-
-  it('should allow urlFor to be called with various options', () => {
-    expect(jsonApi.urlFor({model: 'foo', id: 1})).to.eql('http://myapi.com/foos/1')
-    expect(jsonApi.urlFor({model: 'foo'})).to.eql('http://myapi.com/foos')
-    expect(jsonApi.urlFor({})).to.eql('http://myapi.com/')
-    expect(jsonApi.urlFor()).to.eql('http://myapi.com/')
-    expect(jsonApi.all('foo').urlFor()).to.eql('http://myapi.com/foos')
-  })
-
-  it('should allow pathFor to be called with various options', () => {
-    expect(jsonApi.pathFor({model: 'foo', id: 1})).to.eql('foos/1')
-    expect(jsonApi.pathFor({model: 'foo'})).to.eql('foos')
-    expect(jsonApi.pathFor({})).to.eql('')
-    expect(jsonApi.pathFor()).to.eql('')
-    expect(jsonApi.all('foo').pathFor()).to.eql('foos')
-  })
-
-  it('should allow builders to be used', ()=> {
-    expect(jsonApi.buildUrl()).to.eql('http://myapi.com/')
-  })
-
-  it('should allow builders on all', ()=> {
-    expect(jsonApi.all('foo').all('bar').all('baz').pathFor()).to.eql('foos/bars/bazs')
-
+  afterEach(()=> {
     jsonApi.resetBuilder()
-
-    expect(jsonApi.all('foos').all('bars').all('bazs').pathFor()).to.eql('foos/bars/bazs')
   })
 
-  it('should allow builders to be called to the base url', (done)=> {
-    mockResponse(jsonApi, {
-      data: {
-        data: [
-          {
-            id: '1',
-            type: 'foo',
-            attributes: {
-              title: 'foo 1'
-            }
+  describe('Constructors', ()=> {
+    it('should allow both object and deprecated constructors to be used', ()=> {
+      let jsonApi
+      jsonApi = new JsonApi('http://myapi.com')
+      expect(jsonApi).to.be.a(JsonApi)
+      jsonApi = new JsonApi('http://myapi.com', [])
+      expect(jsonApi).to.be.a(JsonApi)
+      jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
+      expect(jsonApi).to.be.a(JsonApi)
+    })
+
+    it('should allow apiUrl to be set via the initializer object', ()=> {
+      let jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
+      expect(jsonApi.apiUrl).to.eql('http://myapi.com')
+    })
+
+    it('should allow middleware to be set via the initializer object', ()=> {
+      let middleware = [
+        {
+          name: 'm1',
+          req: function (req) {
+            return req
           },
-          {
-            id: '2',
-            type: 'foo',
-            attributes: {
-              title: 'foo 2'
-            }
+          res: function (res) {
+            return res
           }
-        ]
-      }
-    })
-
-    jsonApi.define('foo', {
-      title: ''
-    })
-
-    jsonApi.get().then((foos)=> {
-      expect(foos[0].id).to.eql('1')
-      expect(foos[0].title).to.eql('foo 1')
-      expect(foos[1].id).to.eql('2')
-      expect(foos[1].title).to.eql('foo 2')
-      done()
-    }).catch(err => console.log(err))
-  })
-
-  //{ method: 'GET', url: 'http://myapi.com/', data: {}, params: {} }
-  it('should allow builders to be called with get', (done)=> {
-    let inspectorMiddleware = {
-      name: 'inspector-middleware',
-      req: (payload)=> {
-        expect(payload.req.method).to.be.eql('GET')
-        expect(payload.req.url).to.be.eql('http://myapi.com/')
-        return {}
-      }
-    }
-
-    jsonApi.middleware = [inspectorMiddleware]
-
-    jsonApi.define('foo', {
-      title: ''
-    })
-
-    jsonApi.get().then(()=>done()).catch(()=>done())
-  })
-
-  it('should allow builders to be called with post', (done)=> {
-    let inspectorMiddleware = {
-      name: 'inspector-middleware',
-      req: (payload)=> {
-        expect(payload.req.method).to.be.eql('POST')
-        expect(payload.req.url).to.be.eql('http://myapi.com/foos')
-        expect(payload.req.data).to.be.eql({title: 'foo'})
-        return {}
-      }
-    }
-
-    jsonApi.middleware = [inspectorMiddleware]
-
-    jsonApi.define('foo', {
-      title: ''
-    })
-
-    jsonApi.all('foo').post({title: 'foo'}).then(()=>done()).catch(()=>done())
-  })
-
-  it('should allow builders to be called with patch', (done)=> {
-    let inspectorMiddleware = {
-      name: 'inspector-middleware',
-      req: (payload)=> {
-        expect(payload.req.method).to.be.eql('PATCH')
-        expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
-        expect(payload.req.data).to.be.eql({title: 'bar'})
-        return {}
-      }
-    }
-
-    jsonApi.middleware = [inspectorMiddleware]
-
-    jsonApi.define('foo', {
-      title: ''
-    })
-
-    jsonApi.one('foo', 1).patch({title: 'bar'}).then(()=>done()).catch(()=>done())
-  })
-
-  it('should allow builders to be called with destroy', (done)=> {
-    let inspectorMiddleware = {
-      name: 'inspector-middleware',
-      req: (payload)=> {
-        expect(payload.req.method).to.be.eql('DELETE')
-        expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
-        return {}
-      }
-    }
-
-    jsonApi.middleware = [inspectorMiddleware]
-
-    jsonApi.define('foo', {
-      title: ''
-    })
-
-    jsonApi.one('foo', 1).destroy().then(()=>done()).catch(()=>done())
-  })
-
-  it('should set the apiUrl during setup', ()=> {
-    expect(jsonApi.apiUrl).to.eql('http://myapi.com')
-  })
-
-  it('should expose the serialize and deserialize objects', ()=> {
-    expect(jsonApi.serialize.collection).to.be.a('function')
-    expect(jsonApi.serialize.resource).to.be.a('function')
-    expect(jsonApi.deserialize.collection).to.be.a('function')
-    expect(jsonApi.deserialize.resource).to.be.a('function')
-  })
-
-  it('should have a empty models and middleware properties after instantiation', ()=> {
-    expect(jsonApi.models).to.be.an('object')
-    expect(jsonApi.middleware).to.be.an('array')
-  })
-
-  it('should allow users to register middleware', ()=> {
-    let catMiddleWare = {
-      name: 'cat-middleware',
-      req: function(req) {
-        return req
-      },
-      res: function(res) {
-        return res
-      }
-    }
-    jsonApi.middleware.unshift(catMiddleWare)
-    expect(jsonApi.middleware[0].name).to.eql('cat-middleware')
-  })
-
-  it('should initialize with an empty headers object', ()=> {
-    expect(jsonApi.headers).to.be.an('object')
-    expect(jsonApi.headers).to.eql({})
-  })
-
-  it('should allow users to add headers', ()=> {
-    jsonApi.headers['A-Header-Name'] = 'a value'
-    expect(jsonApi.headers).to.eql({
-      'A-Header-Name':'a value'
-    })
-  })
-
-  it('should allow users to register middleware before or after existing middleware', ()=> {
-    let responseMiddleware = jsonApi.middleware.filter(middleware => middleware.name === 'response')[0]
-    let beforeMiddleware = {
-      name: 'before'
-    }
-    let afterMiddleware = {
-      name: 'after'
-    }
-    let index = jsonApi.middleware.indexOf(responseMiddleware)
-    jsonApi.insertMiddlewareBefore('response', beforeMiddleware)
-    jsonApi.insertMiddlewareAfter('response', afterMiddleware)
-    expect(jsonApi.middleware.indexOf(beforeMiddleware)).to.eql(index)
-    expect(jsonApi.middleware.indexOf(afterMiddleware)).to.eql(index + 2)
-  })
-
-  it('should allow users to define models', ()=> {
-    jsonApi.define('product', {
-      id:    '',
-      title: ''
-    })
-    expect(jsonApi.models['product']).to.be.an('object')
-    expect(jsonApi.models['product']['attributes']).to.have.key('id')
-    expect(jsonApi.models['product']['attributes']).to.have.key('title')
-  })
-
-  it('should construct collection paths for models', ()=> {
-    jsonApi.define('product', {})
-    expect(jsonApi.collectionPathFor('product')).to.eql('products')
-  })
-
-  it('should allow overrides for collection paths', ()=> {
-    jsonApi.define('product', {}, {collectionPath: 'my-products'})
-    expect(jsonApi.collectionPathFor('product')).to.eql('my-products')
-  })
-
-  it('should allow arbitrary collections without a model', ()=> {
-    expect(jsonApi.collectionPathFor('foo')).to.eql('foos')
-  })
-
-  it('should construct single resource paths for models', ()=> {
-    jsonApi.define('product', {})
-    expect(jsonApi.resourcePathFor('product', 1)).to.eql('products/1')
-  })
-
-  it('should construct collection urls for models', ()=> {
-    jsonApi.define('product', {})
-    expect(jsonApi.collectionUrlFor('product')).to.eql('http://myapi.com/products')
-  })
-
-  it('should construct single resource urls for models', ()=> {
-    jsonApi.define('product', {})
-    expect(jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1')
-  })
-
-  it('should make basic find calls', (done)=> {
-    mockResponse(jsonApi, {
-      data: {
-        data: {
-          id: '1',
-          type: 'products',
-          attributes: {
-            title: 'Some Title'
+        },
+        {
+          name: 'm2',
+          req: function (req) {
+            return req
+          },
+          res: function (res) {
+            return res
           }
         }
-      }
+      ]
+
+      let jsonApi = new JsonApi({apiUrl: 'http://myapi.com', middleware: middleware})
+      expect(jsonApi.middleware).to.eql(middleware)
+      expect(jsonApi.apiUrl).to.eql('http://myapi.com')
     })
-    jsonApi.define('product', {
-      title: ''
+
+    it('should set the apiUrl during setup', ()=> {
+      expect(jsonApi.apiUrl).to.eql('http://myapi.com')
     })
-    jsonApi.find('product', 1).then((product)=> {
-      expect(product.id).to.eql('1')
-      expect(product.title).to.eql('Some Title')
-      done()
-    }).catch(err => console.log(err))
+
+    it('should have a empty models and middleware properties after instantiation', ()=> {
+      expect(jsonApi.models).to.be.an('object')
+      expect(jsonApi.middleware).to.be.an('array')
+    })
+
+    it('should initialize with an empty headers object', ()=> {
+      expect(jsonApi.headers).to.be.an('object')
+      expect(jsonApi.headers).to.eql({})
+    })
+
+    it('should allow users to add headers', ()=> {
+      jsonApi.headers['A-Header-Name'] = 'a value'
+      expect(jsonApi.headers).to.eql({
+        'A-Header-Name': 'a value'
+      })
+    })
+
+    it.skip('should throw Exception if the constructor does not receive proper arguments', ()=> {
+      expect(function () {
+        throw new Error('boom!')
+      }).toThrow(/boom/)
+
+      expect(function () {
+        new JsonApi()
+      }).to.throw(Error)
+    })
   })
 
-  it('should make basic findAll calls', (done)=> {
-    mockResponse(jsonApi, {
-      data: {
-        data: [
-          {
+  describe('urlFor, pathFor and path builders', ()=> {
+    it('should construct collection paths for models', ()=> {
+      jsonApi.define('product', {})
+      expect(jsonApi.collectionPathFor('product')).to.eql('products')
+    })
+
+    it('should allow overrides for collection paths', ()=> {
+      jsonApi.define('product', {}, {collectionPath: 'my-products'})
+      expect(jsonApi.collectionPathFor('product')).to.eql('my-products')
+    })
+
+    it('should allow arbitrary collections without a model', ()=> {
+      expect(jsonApi.collectionPathFor('foo')).to.eql('foos')
+    })
+
+    it('should construct single resource paths for models', ()=> {
+      jsonApi.define('product', {})
+      expect(jsonApi.resourcePathFor('product', 1)).to.eql('products/1')
+    })
+
+    it('should construct collection urls for models', ()=> {
+      jsonApi.define('product', {})
+      expect(jsonApi.collectionUrlFor('product')).to.eql('http://myapi.com/products')
+    })
+
+    it('should construct single resource urls for models', ()=> {
+      jsonApi.define('product', {})
+      expect(jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1')
+    })
+
+    it('should allow urlFor to be called with various options', () => {
+      expect(jsonApi.urlFor({model: 'foo', id: 1})).to.eql('http://myapi.com/foos/1')
+      expect(jsonApi.urlFor({model: 'foo'})).to.eql('http://myapi.com/foos')
+      expect(jsonApi.urlFor({})).to.eql('http://myapi.com/')
+      expect(jsonApi.urlFor()).to.eql('http://myapi.com/')
+      expect(jsonApi.all('foo').urlFor()).to.eql('http://myapi.com/foos')
+    })
+
+    it('should allow pathFor to be called with various options', () => {
+      expect(jsonApi.pathFor({model: 'foo', id: 1})).to.eql('foos/1')
+      expect(jsonApi.pathFor({model: 'foo'})).to.eql('foos')
+      expect(jsonApi.pathFor({})).to.eql('')
+      expect(jsonApi.pathFor()).to.eql('')
+      expect(jsonApi.all('foo').pathFor()).to.eql('foos')
+    })
+  })
+
+  describe('Middleware', () => {
+    it('should allow users to register middleware', ()=> {
+      let catMiddleWare = {
+        name: 'cat-middleware',
+        req: function (req) {
+          return req
+        },
+        res: function (res) {
+          return res
+        }
+      }
+      jsonApi.middleware.unshift(catMiddleWare)
+      expect(jsonApi.middleware[0].name).to.eql('cat-middleware')
+    })
+
+    it('should allow users to register middleware before or after existing middleware', ()=> {
+      let responseMiddleware = jsonApi.middleware.filter(middleware => middleware.name === 'response')[0]
+      let beforeMiddleware = {
+        name: 'before'
+      }
+      let afterMiddleware = {
+        name: 'after'
+      }
+      let index = jsonApi.middleware.indexOf(responseMiddleware)
+      jsonApi.insertMiddlewareBefore('response', beforeMiddleware)
+      jsonApi.insertMiddlewareAfter('response', afterMiddleware)
+      expect(jsonApi.middleware.indexOf(beforeMiddleware)).to.eql(index)
+      expect(jsonApi.middleware.indexOf(afterMiddleware)).to.eql(index + 2)
+    })
+
+  })
+
+  describe('Models and serializers', () => {
+    it('should expose the serialize and deserialize objects', ()=> {
+      expect(jsonApi.serialize.collection).to.be.a('function')
+      expect(jsonApi.serialize.resource).to.be.a('function')
+      expect(jsonApi.deserialize.collection).to.be.a('function')
+      expect(jsonApi.deserialize.resource).to.be.a('function')
+    })
+
+    it('should allow users to define models', ()=> {
+      jsonApi.define('product', {
+        id: '',
+        title: ''
+      })
+      expect(jsonApi.models['product']).to.be.an('object')
+      expect(jsonApi.models['product']['attributes']).to.have.key('id')
+      expect(jsonApi.models['product']['attributes']).to.have.key('title')
+    })
+  })
+
+  describe('Basic API calls', () => {
+    it('should make basic find calls', (done)=> {
+      mockResponse(jsonApi, {
+        data: {
+          data: {
             id: '1',
             type: 'products',
             attributes: {
               title: 'Some Title'
             }
+          }
+        }
+      })
+      jsonApi.define('product', {
+        title: ''
+      })
+      jsonApi.find('product', 1).then((product)=> {
+        expect(product.id).to.eql('1')
+        expect(product.title).to.eql('Some Title')
+        done()
+      }).catch(err => console.log(err))
+    })
+
+    it('should make basic findAll calls', (done)=> {
+      mockResponse(jsonApi, {
+        data: {
+          data: [
+            {
+              id: '1',
+              type: 'products',
+              attributes: {
+                title: 'Some Title'
+              }
+            },
+            {
+              id: '2',
+              type: 'products',
+              attributes: {
+                title: 'Another Title'
+              }
+            }
+          ]
+        }
+      })
+      jsonApi.define('product', {
+        title: ''
+      })
+      jsonApi.findAll('product').then((products)=> {
+        expect(products[0].id).to.eql('1')
+        expect(products[0].title).to.eql('Some Title')
+        expect(products[1].id).to.eql('2')
+        expect(products[1].title).to.eql('Another Title')
+        done()
+      }).catch(err => console.log(err))
+    })
+
+    it('should make basic create call', ()=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('POST')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos')
+          expect(payload.req.data).to.be.eql({title: 'foo'})
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.define('foo', {
+        title: ''
+      })
+
+      jsonApi.create('foo', {title: 'foo'}).then(()=>done()).catch(()=>done())
+    })
+
+    it('should include meta information on response objects', (done)=> {
+      mockResponse(jsonApi, {
+        data: {
+          meta: {
+            totalObjects: 1
           },
-          {
-            id: '2',
+          data: [{
+            id: '1',
             type: 'products',
             attributes: {
-              title: 'Another Title'
+              title: 'Some Title'
             }
-          }
-        ]
-      }
+          }]
+        }
+      })
+      jsonApi.define('product', {
+        title: ''
+      })
+      jsonApi.findAll('product').then((products)=> {
+        expect(products.meta.totalObjects).to.eql(1)
+        expect(products[0].id).to.eql('1')
+        expect(products[0].title).to.eql('Some Title')
+        done()
+      }).catch(err => console.log(err))
     })
-    jsonApi.define('product', {
-      title: ''
-    })
-    jsonApi.findAll('product').then((products)=> {
-      expect(products[0].id).to.eql('1')
-      expect(products[0].title).to.eql('Some Title')
-      expect(products[1].id).to.eql('2')
-      expect(products[1].title).to.eql('Another Title')
-      done()
-    }).catch(err => console.log(err))
   })
 
-  it('should make basic create call', ()=> {
-    let inspectorMiddleware = {
-      name: 'inspector-middleware',
-      req: (payload)=> {
-        expect(payload.req.method).to.be.eql('POST')
-        expect(payload.req.url).to.be.eql('http://myapi.com/foos')
-        expect(payload.req.data).to.be.eql({title: 'foo'})
-        return {}
+  describe('Builder pattern for route construction', ()=> {
+    beforeEach(()=> {
+      jsonApi.define('foo', {title: ''})
+      jsonApi.define('bar', {title: ''})
+      jsonApi.define('baz', {title: ''})
+    })
+
+    it('should allow builders to be used', ()=> {
+      expect(jsonApi.buildUrl()).to.eql('http://myapi.com/')
+    })
+
+    it('should allow builders on all', ()=> {
+      expect(jsonApi.all('foo').all('bar').all('baz').pathFor()).to.eql('foos/bars/bazs')
+
+      jsonApi.resetBuilder()
+
+      expect(jsonApi.all('foos').all('bars').all('bazs').pathFor()).to.eql('foos/bars/bazs')
+    })
+
+    it('should allow builders on one', ()=> {
+      expect(jsonApi.one('foo', 1).one('bar', 2).one('baz', 3).pathFor()).to.eql('foos/1/bars/2/bazs/3')
+
+      jsonApi.resetBuilder()
+
+      expect(jsonApi.one('foos', 1).one('bars', 2).one('bazs', 3).pathFor()).to.eql('foos/1/bars/2/bazs/3')
+    })
+
+    it('should allow builders on all and one', ()=> {
+      expect(jsonApi.one('foo', 1).one('bar', 2).all('baz').pathFor()).to.eql('foos/1/bars/2/bazs')
+
+      jsonApi.resetBuilder()
+
+      expect(jsonApi.one('foos', 1).one('bars', 2).all('bazs').pathFor()).to.eql('foos/1/bars/2/bazs')
+    })
+
+    it('should allow builders to be called to the base url', (done)=> {
+      mockResponse(jsonApi, {
+        data: {
+          data: [
+            {
+              id: '1',
+              type: 'foo',
+              attributes: {
+                title: 'foo 1'
+              }
+            }
+          ]
+        }
+      })
+
+      jsonApi.get().then((foos)=> {
+        expect(foos[0].id).to.eql('1')
+        expect(foos[0].title).to.eql('foo 1')
+        done()
+      }).catch(err => console.log(err))
+    })
+
+    it('should allow builders to be called with get', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('GET')
+          expect(payload.req.url).to.be.eql('http://myapi.com/')
+          return {}
+        }
       }
-    }
 
-    jsonApi.middleware = [inspectorMiddleware]
+      jsonApi.middleware = [inspectorMiddleware]
 
-    jsonApi.define('foo', {
-      title: ''
+      jsonApi.get().then(()=>done()).catch(()=>done())
     })
 
-    jsonApi.create('foo', {title: 'foo'}).then(()=>done()).catch(()=>done())
-  })
-
-  it('should include meta information on response objects', (done)=> {
-    mockResponse(jsonApi, {
-      data: {
-        meta: {
-          totalObjects: 1
-        },
-        data: [{
-          id: '1',
-          type: 'products',
-          attributes: {
-            title: 'Some Title'
-          }
-        }]
+    it('should allow builders to be called with get on all', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('GET')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos')
+          return {}
+        }
       }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.all('foo').get().then(()=>done()).catch(()=>done())
     })
-    jsonApi.define('product', {
-      title: ''
+
+    it('should allow builders to be called with get on one', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('GET')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.one('foo', 1).get().then(()=>done()).catch(()=>done())
     })
-    jsonApi.findAll('product').then((products)=> {
-      expect(products.meta.totalObjects).to.eql(1)
-      expect(products[0].id).to.eql('1')
-      expect(products[0].title).to.eql('Some Title')
-      done()
-    }).catch(err => console.log(err))
+
+    it('should allow builders to be called with post', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('POST')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos')
+          expect(payload.req.data).to.be.eql({title: 'foo'})
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.all('foo').post({title: 'foo'}).then(()=>done()).catch(()=>done())
+    })
+
+    it('should allow builders to be called with post with nested one', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('POST')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars')
+          expect(payload.req.data).to.be.eql({title: 'foo'})
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.one('foo', 1).all('bar').post({title: 'foo'}).then(()=>done()).catch(()=>done())
+    })
+
+    it('should allow builders to be called with patch', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('PATCH')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
+          expect(payload.req.data).to.be.eql({title: 'bar'})
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.one('foo', 1).patch({title: 'bar'}).then(()=>done()).catch(()=>done())
+    })
+
+    it('should allow builders to be called with patch with nested one', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('PATCH')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars')
+          expect(payload.req.data).to.be.eql({title: 'bar'})
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.one('foo', 1).all('bar').patch({title: 'bar'}).then(()=>done()).catch(()=>done())
+    })
+
+    it('should allow builders to be called with destroy', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('DELETE')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.one('foo', 1).destroy().then(()=>done()).catch(()=>done())
+    })
+    it('should allow builders to be called with destroy with nested one', (done)=> {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload)=> {
+          expect(payload.req.method).to.be.eql('DELETE')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars/2')
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.one('foo', 1).one('bar', 2).destroy().then(()=>done()).catch(()=>done())
+    })
+
+    it('should Wacky Waving Inflatable Arm-Flailing Tubeman! Wacky Waving Inflatable Arm-Flailing Tubeman! Wacky Waving Inflatable Arm-Flailing Tubeman!', ()=> {
+      jsonApi.one('foo', 1).one('bar', 2).all('foo').one('bar', 3).all('baz').one('baz', 1).one('baz', 2).one('baz', 3)
+      expect(jsonApi.pathFor()).to.be.eql('foos/1/bars/2/foos/bars/3/bazs/bazs/1/bazs/2/bazs/3')
+      expect(jsonApi.urlFor()).to.be.eql('http://myapi.com/foos/1/bars/2/foos/bars/3/bazs/bazs/1/bazs/2/bazs/3')
+    })
+
   })
 
 })

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -9,6 +9,111 @@ describe('JsonApi', ()=> {
     jsonApi = new JsonApi('http://myapi.com')
   })
 
+  afterEach(()=>{
+    jsonApi.resetBuilder()
+  })
+
+  it('should allow urlFor to be called with various options', () => {
+    expect(jsonApi.urlFor({model: 'foo', id: 1})).to.eql('http://myapi.com/foos/1')
+    expect(jsonApi.urlFor({model: 'foo'})).to.eql('http://myapi.com/foos')
+    expect(jsonApi.urlFor({})).to.eql('http://myapi.com/')
+    expect(jsonApi.urlFor()).to.eql('http://myapi.com/')
+    expect(jsonApi.all('foo').urlFor()).to.eql('http://myapi.com/foos')
+  })
+
+  it('should allow pathFor to be called with various options', () => {
+    expect(jsonApi.pathFor({model: 'foo', id: 1})).to.eql('foos/1')
+    expect(jsonApi.pathFor({model: 'foo'})).to.eql('foos')
+    expect(jsonApi.pathFor({})).to.eql('')
+    expect(jsonApi.pathFor()).to.eql('')
+    expect(jsonApi.all('foo').pathFor()).to.eql('foos')
+  })
+
+  it('should allow builders to be used', ()=> {
+    expect(jsonApi.buildUrl()).to.eql('http://myapi.com/')
+  })
+
+  it('should allow builders on all', ()=> {
+    expect(jsonApi.all('foo').all('bar').all('baz').pathFor()).to.eql('foos/bars/bazs')
+
+    jsonApi.resetBuilder()
+
+    expect(jsonApi.all('foos').all('bars').all('bazs').pathFor()).to.eql('foos/bars/bazs')
+  })
+
+  it('should allow builders to be called to the base url', (done)=> {
+    mockResponse(jsonApi, {
+      data: {
+        data: [
+          {
+            id: '1',
+            type: 'foo',
+            attributes: {
+              title: 'foo 1'
+            }
+          },
+          {
+            id: '2',
+            type: 'foo',
+            attributes: {
+              title: 'foo 2'
+            }
+          }
+        ]
+      }
+    })
+
+    jsonApi.define('foo', {
+      title: ''
+    })
+
+    jsonApi.get().then((foos)=> {
+      expect(foos[0].id).to.eql('1')
+      expect(foos[0].title).to.eql('foo 1')
+      expect(foos[1].id).to.eql('2')
+      expect(foos[1].title).to.eql('foo 2')
+      done()
+    }).catch(err => console.log(err))
+  })
+
+  it('should allow builders to be called with get', (done)=> {
+    mockResponse(jsonApi, {
+      data: {
+        data: [
+          {
+            id: '1',
+            type: 'foo',
+            attributes: {
+              title: 'foo 1'
+            }
+          },
+          {
+            id: '2',
+            type: 'foo',
+            attributes: {
+              title: 'foo 2'
+            }
+          }
+        ]
+      }
+    })
+
+    jsonApi.define('foo', {
+      title: ''
+    })
+
+    jsonApi.get().then((foos)=> {
+      expect(foos[0].id).to.eql('1')
+      expect(foos[0].title).to.eql('foo 1')
+      expect(foos[1].id).to.eql('2')
+      expect(foos[1].title).to.eql('foo 2')
+      done()
+    }).catch(err => console.log(err))
+  })
+
+  it.skip('should allow builders to be called with post', ()=> {
+  })
+
   it('should set the apiUrl during setup', ()=> {
     expect(jsonApi.apiUrl).to.eql('http://myapi.com')
   })
@@ -86,6 +191,10 @@ describe('JsonApi', ()=> {
     expect(jsonApi.collectionPathFor('product')).to.eql('my-products')
   })
 
+  it('should allow arbitrary collections without a model', ()=> {
+    expect(jsonApi.collectionPathFor('foo')).to.eql('foos')
+  })
+
   it('should construct single resource paths for models', ()=> {
     jsonApi.define('product', {})
     expect(jsonApi.resourcePathFor('product', 1)).to.eql('products/1')
@@ -154,6 +263,9 @@ describe('JsonApi', ()=> {
       expect(products[1].title).to.eql('Another Title')
       done()
     }).catch(err => console.log(err))
+  })
+
+  it.skip('should make basic create call', ()=> {
   })
 
   it('should include meta information on response objects', (done)=> {


### PR DESCRIPTION
## Priority
No

## Screenshot
<img width="825" alt="screen shot 2016-05-06 at 3 31 52 am" src="https://cloud.githubusercontent.com/assets/1641464/15066954/1d04841a-133b-11e6-975c-9a8744ea4480.png">

## What Changed & Why
- Added url builder pattern.
- Why: I wanted to try ES6, and it was an open issue.
- Moved tests to nested describe blocks

## Testing
`npm test`
- Build some url and nested urls and use it! (hallelujah!)

## Bug/Ticket Tracker
#11 

## Documentation
Done

## In Progress/Follow Up
Didn't **RTFM**: 

- Can a root route be a valid resource? Typically we have end points like `/photos/1` can `/1` be a valid end point?
- Should we make the following observation?
  - `.get()` can be used for `/resources` and `/resources/1`
  - `.post({})` can be used for `/resources`
  - `.patch({})` can be used for `/resources/1`
  - `.destroy()` can be used for `/resources/1`
  - Issue is, what does `POST http://foo.com/bars/1` mean?
- Should we also make the following rules on the url builder? `(resources/:id/)*(resources|resources/:id)`
  - Issue is, what does `/foos/bars/bazs/1/bars/2/bars/3` (all().all().one().one().one()) mean?
- Tried to get istanbul up and running but couldn't get it to work... 
- How should tests be approached? Spin up a real API server to test against?

## Legal/Security/Privacy
N/A

## Third-Party
Added Minilog for logger. This works both on the server side and client side. Happy to save a few bytes by stubbing out console.* methods.

## People
@Emerson @derek-watson @themarkappleby 