### PR TITLE
Feature/standard

### DIFF
--- a/middleware/json-api/_serialize.js
+++ b/middleware/json-api/_serialize.js
@@ -1,11 +1,13 @@
 const _ = require('lodash')
 const pluralize = require('pluralize')
 
-function collection(modelName, items) {
-  return items.map(item => { return resource.call(this, modelName, item) })
+function collection (modelName, items) {
+  return items.map(item => {
+    return resource.call(this, modelName, item)
+  })
 }
 
-function resource(modelName, item) {
+function resource (modelName, item) {
   let model = this.modelFor(modelName)
   let options = model.options || {}
   let readOnly = options.readOnly || []
@@ -13,16 +15,16 @@ function resource(modelName, item) {
   let serializedAttributes = {}
   let serializedRelationships = {}
   let serializedResource = {}
-  if(model.options.serializer) {
+  if (model.options.serializer) {
     return model.options.serializer.call(this, item)
   }
-  _.forOwn(model.attributes, (value, key)=> {
-    if(isReadOnly(key, readOnly)) {
+  _.forOwn(model.attributes, (value, key) => {
+    if (isReadOnly(key, readOnly)) {
       return
     }
-    if(isRelationship(value)) {
+    if (isRelationship(value)) {
       serializeRelationship(key, item[key], value, serializedRelationships)
-    }else{
+    } else {
       serializedAttributes[key] = item[key]
     }
   })
@@ -30,39 +32,39 @@ function resource(modelName, item) {
   serializedResource.type = typeName
   serializedResource.attributes = serializedAttributes
   serializedResource.relationships = serializedRelationships
-  if(item.id) {
+  if (item.id) {
     serializedResource.id = item.id
   }
   return serializedResource
 }
 
-function isReadOnly(attribute, readOnly) {
+function isReadOnly (attribute, readOnly) {
   return readOnly.indexOf(attribute) !== -1
 }
 
-function isRelationship(attribute) {
+function isRelationship (attribute) {
   return (_.isPlainObject(attribute) && _.includes(['hasOne', 'hasMany'], attribute.jsonApi))
 }
 
-function serializeRelationship(relationshipName, relationship, relationshipType, serializeRelationships) {
-  if(relationshipType.jsonApi === 'hasMany') {
+function serializeRelationship (relationshipName, relationship, relationshipType, serializeRelationships) {
+  if (relationshipType.jsonApi === 'hasMany') {
     serializeRelationships[relationshipName] = serializeHasMany(relationship, relationshipType.type)
   }
-  if(relationshipType.jsonApi === 'hasOne') {
+  if (relationshipType.jsonApi === 'hasOne') {
     serializeRelationships[relationshipName] = serializeHasOne(relationship, relationshipType.type)
   }
 }
 
-function serializeHasMany(relationships, type) {
+function serializeHasMany (relationships, type) {
   return {
-    data: _.map(relationships, (item)=> {
+    data: _.map(relationships, (item) => {
       return {id: item.id, type: type}
     })
   }
 }
 
-function serializeHasOne(relationship, type) {
-  if(!relationship) {
+function serializeHasOne (relationship, type) {
+  if (!relationship) {
     return null
   }
   return {

--- a/middleware/json-api/rails-params-serializer.js
+++ b/middleware/json-api/rails-params-serializer.js
@@ -2,9 +2,9 @@ const Qs = require('qs')
 
 module.exports = {
   name: 'rails-params-serializer',
-  req: (payload)=> {
-    if(payload.req.method === 'GET') {
-      payload.req.paramsSerializer = function(params) {
+  req: (payload) => {
+    if (payload.req.method === 'GET') {
+      payload.req.paramsSerializer = function (params) {
         return Qs.stringify(params, {
           arrayFormat: 'brackets',
           encode: false

--- a/middleware/json-api/req-delete.js
+++ b/middleware/json-api/req-delete.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'DELETE',
-  req: (payload)=> {
-    if(payload.req.method === 'DELETE') {
+  req: (payload) => {
+    if (payload.req.method === 'DELETE') {
       payload.req.headers = {
         'Content-Type': 'application/vnd.api+json',
         'Accept': 'application/vnd.api+json'

--- a/middleware/json-api/req-headers.js
+++ b/middleware/json-api/req-headers.js
@@ -2,7 +2,7 @@ const isEmpty = require('lodash').isEmpty
 
 module.exports = {
   name: 'HEADER',
-  req: (payload)=> {
+  req: (payload) => {
     if (!isEmpty(payload.jsonApi.headers)) {
       payload.req.headers = Object.assign({}, payload.req.headers, payload.jsonApi.headers)
     }

--- a/middleware/json-api/req-patch.js
+++ b/middleware/json-api/req-patch.js
@@ -2,19 +2,19 @@ const serialize = require('./_serialize')
 
 module.exports = {
   name: 'PATCH',
-  req: (payload)=> {
+  req: (payload) => {
     let jsonApi = payload.jsonApi
 
-    if(payload.req.method === 'PATCH') {
+    if (payload.req.method === 'PATCH') {
       payload.req.headers = {
         'Content-Type': 'application/vnd.api+json',
         'Accept': 'application/vnd.api+json'
       }
-      if(payload.req.data.constructor === Array) {
+      if (payload.req.data.constructor === Array) {
         payload.req.data = {
-            data: serialize.collection.call(jsonApi, payload.req.model, payload.req.data)
+          data: serialize.collection.call(jsonApi, payload.req.model, payload.req.data)
         }
-      }else{
+      } else {
         payload.req.data = {
           data: serialize.resource.call(jsonApi, payload.req.model, payload.req.data)
         }

--- a/middleware/json-api/req-post.js
+++ b/middleware/json-api/req-post.js
@@ -2,19 +2,19 @@ const serialize = require('./_serialize')
 
 module.exports = {
   name: 'POST',
-  req: (payload)=> {
+  req: (payload) => {
     let jsonApi = payload.jsonApi
 
-    if(payload.req.method === 'POST') {
+    if (payload.req.method === 'POST') {
       payload.req.headers = {
         'Content-Type': 'application/vnd.api+json',
         'Accept': 'application/vnd.api+json'
       }
-      if(payload.req.data.constructor === Array) {
+      if (payload.req.data.constructor === Array) {
         payload.req.data = {
-            data: serialize.collection.call(jsonApi, payload.req.model, payload.req.data)
+          data: serialize.collection.call(jsonApi, payload.req.model, payload.req.data)
         }
-      }else{
+      } else {
         payload.req.data = {
           data: serialize.resource.call(jsonApi, payload.req.model, payload.req.data)
         }

--- a/middleware/json-api/res-deserialize.js
+++ b/middleware/json-api/res-deserialize.js
@@ -1,38 +1,38 @@
 const deserialize = require('./_deserialize')
 const _ = require('lodash')
 
-function needsDeserialization(method) {
+function needsDeserialization (method) {
   return ['GET', 'PATCH', 'POST'].indexOf(method) !== -1
 }
 
-function isCollection(responseData) {
+function isCollection (responseData) {
   return _.isArray(responseData)
 }
 
 module.exports = {
   name: 'response',
-  res: function(payload) {
+  res: function (payload) {
     /*
-    *   Note: The axios ajax response attaches the actual response data to
-    *         `res.data`. JSON API Resources also passes back the response with
-    *         a `data` attribute. This means we have `res.data.data`.
-    */
-    let jsonApi  = payload.jsonApi
-    let req      = payload.req
-    let res      = payload.res.data
+     *   Note: The axios ajax response attaches the actual response data to
+     *         `res.data`. JSON API Resources also passes back the response with
+     *         a `data` attribute. This means we have `res.data.data`.
+     */
+    let jsonApi = payload.jsonApi
+    let req = payload.req
+    let res = payload.res.data
     let included = res.included
 
     let deserializedResponse = null
 
-    if(needsDeserialization(req.method)) {
-      if(isCollection(res.data)) {
+    if (needsDeserialization(req.method)) {
+      if (isCollection(res.data)) {
         deserializedResponse = deserialize.collection.call(jsonApi, res.data, included, req.model)
-      }else{
+      } else {
         deserializedResponse = deserialize.resource.call(jsonApi, res.data, included, req.model)
       }
     }
 
-    if(res && res.meta) {
+    if (res && res.meta) {
       deserializedResponse.meta = res.meta
     }
 

--- a/middleware/json-api/res-errors.js
+++ b/middleware/json-api/res-errors.js
@@ -1,23 +1,23 @@
-function buildErrors(serverErrors) {
-  if(!serverErrors) {
+function buildErrors (serverErrors) {
+  if (!serverErrors) {
     console.log('Unidentified error')
     return
-  }else{
+  } else {
     let errors = {}
-    serverErrors.errors.forEach((error)=> {
+    serverErrors.errors.forEach((error) => {
       errors[errorKey(error.source)] = error.title
     })
     return errors
   }
 }
 
-function errorKey(source) {
+function errorKey (source) {
   return source.pointer.split('/').pop()
 }
 
 module.exports = {
   name: 'errors',
-  error: function(payload) {
+  error: function (payload) {
     return buildErrors(payload.data)
   }
 }

--- a/middleware/request.js
+++ b/middleware/request.js
@@ -1,8 +1,6 @@
-const Promise = require('es6-promise').Promise
-
 module.exports = {
   name: 'axios-request',
-  req: function(payload) {
+  req: function (payload) {
     let jsonApi = payload.jsonApi
     return jsonApi.axios(payload.req)
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Don't just consume your JSON API, Devour it...",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -37,7 +37,8 @@
     "babel-register": "^6.8.0",
     "expect.js": "^0.3.1",
     "istanbul": "1.0.0-alpha.2",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "standard": "^7.0.1"
   },
   "dependencies": {
     "axios": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Don't just consume your JSON API, Devour it...",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "standard && mocha"
   },
   "repository": {
     "type": "git",

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -1,20 +1,21 @@
+/* global describe, it, beforeEach, afterEach */
+
 import JsonApi from '../../index'
 import mockResponse from '../helpers/mock-response'
 import expect from 'expect.js'
 
-describe('JsonApi', ()=> {
-
+describe('JsonApi', () => {
   var jsonApi = null
-  beforeEach(()=> {
+  beforeEach(() => {
     jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
   })
 
-  afterEach(()=> {
+  afterEach(() => {
     jsonApi.resetBuilder()
   })
 
-  describe('Constructors', ()=> {
-    it('should allow both object and deprecated constructors to be used', ()=> {
+  describe('Constructors', () => {
+    it('should allow both object and deprecated constructors to be used', () => {
       let jsonApi
       jsonApi = new JsonApi('http://myapi.com')
       expect(jsonApi).to.be.a(JsonApi)
@@ -24,12 +25,12 @@ describe('JsonApi', ()=> {
       expect(jsonApi).to.be.a(JsonApi)
     })
 
-    it('should allow apiUrl to be set via the initializer object', ()=> {
+    it('should allow apiUrl to be set via the initializer object', () => {
       let jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
       expect(jsonApi.apiUrl).to.eql('http://myapi.com')
     })
 
-    it('should allow middleware to be set via the initializer object', ()=> {
+    it('should allow middleware to be set via the initializer object', () => {
       let middleware = [
         {
           name: 'm1',
@@ -56,64 +57,60 @@ describe('JsonApi', ()=> {
       expect(jsonApi.apiUrl).to.eql('http://myapi.com')
     })
 
-    it('should set the apiUrl during setup', ()=> {
+    it('should set the apiUrl during setup', () => {
       expect(jsonApi.apiUrl).to.eql('http://myapi.com')
     })
 
-    it('should have a empty models and middleware properties after instantiation', ()=> {
+    it('should have a empty models and middleware properties after instantiation', () => {
       expect(jsonApi.models).to.be.an('object')
       expect(jsonApi.middleware).to.be.an('array')
     })
 
-    it('should initialize with an empty headers object', ()=> {
+    it('should initialize with an empty headers object', () => {
       expect(jsonApi.headers).to.be.an('object')
       expect(jsonApi.headers).to.eql({})
     })
 
-    it('should allow users to add headers', ()=> {
+    it('should allow users to add headers', () => {
       jsonApi.headers['A-Header-Name'] = 'a value'
       expect(jsonApi.headers).to.eql({
         'A-Header-Name': 'a value'
       })
     })
 
-    it.skip('should throw Exception if the constructor does not receive proper arguments', ()=> {
+    it.skip('should throw Exception if the constructor does not receive proper arguments', () => {
       expect(function () {
         throw new Error('boom!')
       }).toThrow(/boom/)
-
-      expect(function () {
-        new JsonApi()
-      }).to.throw(Error)
     })
   })
 
-  describe('urlFor, pathFor and path builders', ()=> {
-    it('should construct collection paths for models', ()=> {
+  describe('urlFor, pathFor and path builders', () => {
+    it('should construct collection paths for models', () => {
       jsonApi.define('product', {})
       expect(jsonApi.collectionPathFor('product')).to.eql('products')
     })
 
-    it('should allow overrides for collection paths', ()=> {
+    it('should allow overrides for collection paths', () => {
       jsonApi.define('product', {}, {collectionPath: 'my-products'})
       expect(jsonApi.collectionPathFor('product')).to.eql('my-products')
     })
 
-    it('should allow arbitrary collections without a model', ()=> {
+    it('should allow arbitrary collections without a model', () => {
       expect(jsonApi.collectionPathFor('foo')).to.eql('foos')
     })
 
-    it('should construct single resource paths for models', ()=> {
+    it('should construct single resource paths for models', () => {
       jsonApi.define('product', {})
       expect(jsonApi.resourcePathFor('product', 1)).to.eql('products/1')
     })
 
-    it('should construct collection urls for models', ()=> {
+    it('should construct collection urls for models', () => {
       jsonApi.define('product', {})
       expect(jsonApi.collectionUrlFor('product')).to.eql('http://myapi.com/products')
     })
 
-    it('should construct single resource urls for models', ()=> {
+    it('should construct single resource urls for models', () => {
       jsonApi.define('product', {})
       expect(jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1')
     })
@@ -136,7 +133,7 @@ describe('JsonApi', ()=> {
   })
 
   describe('Middleware', () => {
-    it('should allow users to register middleware', ()=> {
+    it('should allow users to register middleware', () => {
       let catMiddleWare = {
         name: 'cat-middleware',
         req: function (req) {
@@ -150,7 +147,7 @@ describe('JsonApi', ()=> {
       expect(jsonApi.middleware[0].name).to.eql('cat-middleware')
     })
 
-    it('should allow users to register middleware before or after existing middleware', ()=> {
+    it('should allow users to register middleware before or after existing middleware', () => {
       let responseMiddleware = jsonApi.middleware.filter(middleware => middleware.name === 'response')[0]
       let beforeMiddleware = {
         name: 'before'
@@ -164,18 +161,17 @@ describe('JsonApi', ()=> {
       expect(jsonApi.middleware.indexOf(beforeMiddleware)).to.eql(index)
       expect(jsonApi.middleware.indexOf(afterMiddleware)).to.eql(index + 2)
     })
-
   })
 
   describe('Models and serializers', () => {
-    it('should expose the serialize and deserialize objects', ()=> {
+    it('should expose the serialize and deserialize objects', () => {
       expect(jsonApi.serialize.collection).to.be.a('function')
       expect(jsonApi.serialize.resource).to.be.a('function')
       expect(jsonApi.deserialize.collection).to.be.a('function')
       expect(jsonApi.deserialize.resource).to.be.a('function')
     })
 
-    it('should allow users to define models', ()=> {
+    it('should allow users to define models', () => {
       jsonApi.define('product', {
         id: '',
         title: ''
@@ -187,7 +183,7 @@ describe('JsonApi', ()=> {
   })
 
   describe('Basic API calls', () => {
-    it('should make basic find calls', (done)=> {
+    it('should make basic find calls', (done) => {
       mockResponse(jsonApi, {
         data: {
           data: {
@@ -202,14 +198,14 @@ describe('JsonApi', ()=> {
       jsonApi.define('product', {
         title: ''
       })
-      jsonApi.find('product', 1).then((product)=> {
+      jsonApi.find('product', 1).then((product) => {
         expect(product.id).to.eql('1')
         expect(product.title).to.eql('Some Title')
         done()
       }).catch(err => console.log(err))
     })
 
-    it('should make basic findAll calls', (done)=> {
+    it('should make basic findAll calls', (done) => {
       mockResponse(jsonApi, {
         data: {
           data: [
@@ -233,7 +229,7 @@ describe('JsonApi', ()=> {
       jsonApi.define('product', {
         title: ''
       })
-      jsonApi.findAll('product').then((products)=> {
+      jsonApi.findAll('product').then((products) => {
         expect(products[0].id).to.eql('1')
         expect(products[0].title).to.eql('Some Title')
         expect(products[1].id).to.eql('2')
@@ -242,10 +238,10 @@ describe('JsonApi', ()=> {
       }).catch(err => console.log(err))
     })
 
-    it('should make basic create call', ()=> {
+    it('should make basic create call', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('POST')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos')
           expect(payload.req.data).to.be.eql({title: 'foo'})
@@ -259,10 +255,10 @@ describe('JsonApi', ()=> {
         title: ''
       })
 
-      jsonApi.create('foo', {title: 'foo'}).then(()=>done()).catch(()=>done())
+      jsonApi.create('foo', {title: 'foo'}).then(() => done()).catch(() => done())
     })
 
-    it('should include meta information on response objects', (done)=> {
+    it('should include meta information on response objects', (done) => {
       mockResponse(jsonApi, {
         data: {
           meta: {
@@ -280,7 +276,7 @@ describe('JsonApi', ()=> {
       jsonApi.define('product', {
         title: ''
       })
-      jsonApi.findAll('product').then((products)=> {
+      jsonApi.findAll('product').then((products) => {
         expect(products.meta.totalObjects).to.eql(1)
         expect(products[0].id).to.eql('1')
         expect(products[0].title).to.eql('Some Title')
@@ -289,27 +285,28 @@ describe('JsonApi', ()=> {
     })
   })
 
-  describe('Builder pattern for route construction', ()=> {
-    beforeEach(()=> {
+  describe('Builder pattern for route construction', () => {
+    beforeEach(() => {
       jsonApi.define('foo', {title: ''})
       jsonApi.define('bar', {title: ''})
       jsonApi.define('baz', {title: ''})
     })
 
-    it('should respect resetBuilderOnCall', (done)=> {
+    it('should respect resetBuilderOnCall', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/')
           return {}
         }
       }
       jsonApi.middleware = [inspectorMiddleware]
-      jsonApi.get().then(()=> {
+      jsonApi.get()
+        .then(() => {
           let inspectorMiddleware = {
             name: 'inspector-middleware',
-            req: (payload)=> {
+            req: (payload) => {
               expect(payload.req.method).to.be.eql('GET')
               expect(payload.req.url).to.be.eql('http://myapi.com/foos')
               return {}
@@ -318,17 +315,17 @@ describe('JsonApi', ()=> {
           jsonApi.middleware = [inspectorMiddleware]
           return jsonApi.all('foo').get()
         })
-        .then(()=>done())
-        .catch(()=>done())
+        .then(() => done())
+        .catch(() => done())
 
       expect(jsonApi.buildUrl()).to.eql('http://myapi.com/')
     })
 
-    it('should respect resetBuilderOnCall when it is disabled', (done)=> {
+    it('should respect resetBuilderOnCall when it is disabled', (done) => {
       jsonApi = new JsonApi({apiUrl: 'http://myapi.com', resetBuilderOnCall: false})
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
           return {}
@@ -337,11 +334,10 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.one('foo', 1).get().then(()=>{
-
+      jsonApi.one('foo', 1).get().then(() => {
         let inspectorMiddleware = {
           name: 'inspector-middleware',
-          req: (payload)=> {
+          req: (payload) => {
             expect(payload.req.method).to.be.eql('GET')
             expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars')
             return {}
@@ -350,15 +346,15 @@ describe('JsonApi', ()=> {
 
         jsonApi.middleware = [inspectorMiddleware]
 
-        return jsonApi.all('bar').get().then(()=>done())
-      }).catch(()=>done())
+        return jsonApi.all('bar').get().then(() => done())
+      }).catch(() => done())
     })
 
-    it('should allow builders to be used', ()=> {
+    it('should allow builders to be used', () => {
       expect(jsonApi.buildUrl()).to.eql('http://myapi.com/')
     })
 
-    it('should allow builders on all', ()=> {
+    it('should allow builders on all', () => {
       expect(jsonApi.all('foo').all('bar').all('baz').pathFor()).to.eql('foos/bars/bazs')
 
       jsonApi.resetBuilder()
@@ -366,7 +362,7 @@ describe('JsonApi', ()=> {
       expect(jsonApi.all('foos').all('bars').all('bazs').pathFor()).to.eql('foos/bars/bazs')
     })
 
-    it('should allow builders on one', ()=> {
+    it('should allow builders on one', () => {
       expect(jsonApi.one('foo', 1).one('bar', 2).one('baz', 3).pathFor()).to.eql('foos/1/bars/2/bazs/3')
 
       jsonApi.resetBuilder()
@@ -374,7 +370,7 @@ describe('JsonApi', ()=> {
       expect(jsonApi.one('foos', 1).one('bars', 2).one('bazs', 3).pathFor()).to.eql('foos/1/bars/2/bazs/3')
     })
 
-    it('should allow builders on all and one', ()=> {
+    it('should allow builders on all and one', () => {
       expect(jsonApi.one('foo', 1).one('bar', 2).all('baz').pathFor()).to.eql('foos/1/bars/2/bazs')
 
       jsonApi.resetBuilder()
@@ -382,7 +378,7 @@ describe('JsonApi', ()=> {
       expect(jsonApi.one('foos', 1).one('bars', 2).all('bazs').pathFor()).to.eql('foos/1/bars/2/bazs')
     })
 
-    it('should allow builders to be called to the base url', (done)=> {
+    it('should allow builders to be called to the base url', (done) => {
       mockResponse(jsonApi, {
         data: {
           data: [
@@ -397,17 +393,17 @@ describe('JsonApi', ()=> {
         }
       })
 
-      jsonApi.get().then((foos)=> {
+      jsonApi.get().then((foos) => {
         expect(foos[0].id).to.eql('1')
         expect(foos[0].title).to.eql('foo 1')
         done()
       }).catch(err => console.log(err))
     })
 
-    it('should allow builders to be called with get', (done)=> {
+    it('should allow builders to be called with get', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/')
           return {}
@@ -416,13 +412,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.get().then(()=>done()).catch(()=>done())
+      jsonApi.get().then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with get with query params', (done)=> {
+    it('should allow builders to be called with get with query params', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/')
           expect(payload.req.params).to.be.eql({page: {number: 2}})
@@ -432,13 +428,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.get({page: {number: 2}}).then(()=>done()).catch(()=>done())
+      jsonApi.get({page: {number: 2}}).then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with get on all', (done)=> {
+    it('should allow builders to be called with get on all', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos')
           return {}
@@ -447,13 +443,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.all('foo').get().then(()=>done()).catch(()=>done())
+      jsonApi.all('foo').get().then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with get on one', (done)=> {
+    it('should allow builders to be called with get on one', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
           return {}
@@ -462,13 +458,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.one('foo', 1).get().then(()=>done()).catch(()=>done())
+      jsonApi.one('foo', 1).get().then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with post', (done)=> {
+    it('should allow builders to be called with post', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('POST')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos')
           expect(payload.req.data).to.be.eql({title: 'foo'})
@@ -478,13 +474,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.all('foo').post({title: 'foo'}).then(()=>done()).catch(()=>done())
+      jsonApi.all('foo').post({title: 'foo'}).then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with post with nested one', (done)=> {
+    it('should allow builders to be called with post with nested one', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('POST')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars')
           expect(payload.req.data).to.be.eql({title: 'foo'})
@@ -494,13 +490,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.one('foo', 1).all('bar').post({title: 'foo'}).then(()=>done()).catch(()=>done())
+      jsonApi.one('foo', 1).all('bar').post({title: 'foo'}).then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with patch', (done)=> {
+    it('should allow builders to be called with patch', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('PATCH')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
           expect(payload.req.data).to.be.eql({title: 'bar'})
@@ -510,13 +506,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.one('foo', 1).patch({title: 'bar'}).then(()=>done()).catch(()=>done())
+      jsonApi.one('foo', 1).patch({title: 'bar'}).then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with patch with nested one', (done)=> {
+    it('should allow builders to be called with patch with nested one', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('PATCH')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars')
           expect(payload.req.data).to.be.eql({title: 'bar'})
@@ -526,13 +522,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.one('foo', 1).all('bar').patch({title: 'bar'}).then(()=>done()).catch(()=>done())
+      jsonApi.one('foo', 1).all('bar').patch({title: 'bar'}).then(() => done()).catch(() => done())
     })
 
-    it('should allow builders to be called with destroy', (done)=> {
+    it('should allow builders to be called with destroy', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('DELETE')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
           return {}
@@ -541,12 +537,12 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.one('foo', 1).destroy().then(()=>done()).catch(()=>done())
+      jsonApi.one('foo', 1).destroy().then(() => done()).catch(() => done())
     })
-    it('should allow builders to be called with destroy with nested one', (done)=> {
+    it('should allow builders to be called with destroy with nested one', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',
-        req: (payload)=> {
+        req: (payload) => {
           expect(payload.req.method).to.be.eql('DELETE')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars/2')
           return {}
@@ -555,15 +551,13 @@ describe('JsonApi', ()=> {
 
       jsonApi.middleware = [inspectorMiddleware]
 
-      jsonApi.one('foo', 1).one('bar', 2).destroy().then(()=>done()).catch(()=>done())
+      jsonApi.one('foo', 1).one('bar', 2).destroy().then(() => done()).catch(() => done())
     })
 
-    it('should Wacky Waving Inflatable Arm-Flailing Tubeman! Wacky Waving Inflatable Arm-Flailing Tubeman! Wacky Waving Inflatable Arm-Flailing Tubeman!', ()=> {
+    it('should Wacky Waving Inflatable Arm-Flailing Tubeman! Wacky Waving Inflatable Arm-Flailing Tubeman! Wacky Waving Inflatable Arm-Flailing Tubeman!', () => {
       jsonApi.one('foo', 1).one('bar', 2).all('foo').one('bar', 3).all('baz').one('baz', 1).one('baz', 2).one('baz', 3)
       expect(jsonApi.pathFor()).to.be.eql('foos/1/bars/2/foos/bars/3/bazs/bazs/1/bazs/2/bazs/3')
       expect(jsonApi.urlFor()).to.be.eql('http://myapi.com/foos/1/bars/2/foos/bars/3/bazs/bazs/1/bazs/2/bazs/3')
     })
-
   })
-
 })

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -1,16 +1,16 @@
+/* global describe, it, before */
+
 import JsonApi from '../../index'
 import deserialize from '../../middleware/json-api/_deserialize'
-import mockResponse from '../helpers/mock-response'
 import expect from 'expect.js'
 
-describe('deserialize', ()=> {
-
+describe('deserialize', () => {
   var jsonApi = null
-  before(()=> {
+  before(() => {
     jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
   })
 
-  it('should deserialize single resource items', ()=> {
+  it('should deserialize single resource items', () => {
     jsonApi.define('product', {
       title: '',
       about: ''
@@ -31,7 +31,7 @@ describe('deserialize', ()=> {
     expect(product.about).to.eql('Some about')
   })
 
-  it('should deserialize hasMany relations', ()=> {
+  it('should deserialize hasMany relations', () => {
     jsonApi.define('product', {
       title: '',
       tags: {
@@ -63,12 +63,6 @@ describe('deserialize', ()=> {
         {id: '6', type: 'tags', attributes: {name: 'two'}}
       ]
     }
-    let payload = {
-      res: {
-        data: mockResponse
-      },
-      jsonApi: jsonApi,
-    }
     let product = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
     expect(product.id).to.eql('1')
     expect(product.title).to.eql('hello')
@@ -79,7 +73,7 @@ describe('deserialize', ()=> {
     expect(product.tags[1].name).to.eql('two')
   })
 
-  it('should deserialize collections of resource items', ()=> {
+  it('should deserialize collections of resource items', () => {
     jsonApi.define('product', {
       title: '',
       about: ''
@@ -112,5 +106,4 @@ describe('deserialize', ()=> {
     expect(products[1].title).to.eql('Another Title')
     expect(products[1].about).to.eql('Another about')
   })
-
 })

--- a/test/api/serialize-test.js
+++ b/test/api/serialize-test.js
@@ -1,16 +1,16 @@
+/* global describe, it, beforeEach */
+
 import JsonApi from '../../index'
 import serialize from '../../middleware/json-api/_serialize'
-import mockResponse from '../helpers/mock-response'
 import expect from 'expect.js'
 
-describe('serialize', ()=> {
-
+describe('serialize', () => {
   var jsonApi = null
-  beforeEach(()=> {
+  beforeEach(() => {
     jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
   })
 
-  it('should serialize resource items', ()=> {
+  it('should serialize resource items', () => {
     jsonApi.define('product', {
       title: '',
       about: ''
@@ -21,7 +21,7 @@ describe('serialize', ()=> {
     expect(serializedItem.attributes.about).to.eql('World')
   })
 
-  it('should serialize hasMany relationships', ()=> {
+  it('should serialize hasMany relationships', () => {
     jsonApi.define('product', {
       title: '',
       about: '',
@@ -51,7 +51,7 @@ describe('serialize', ()=> {
     expect(serializedItem.relationships.tags.data[2].type).to.eql('tags')
   })
 
-  it('should serialize hasOne relationships', ()=> {
+  it('should serialize hasOne relationships', () => {
     jsonApi.define('product', {
       title: '',
       about: '',
@@ -73,11 +73,11 @@ describe('serialize', ()=> {
     expect(serializedItem.relationships.tags.data.type).to.eql('tags')
   })
 
-  it('should not serialize read only attributes', ()=> {
+  it('should not serialize read only attributes', () => {
     jsonApi.define('product', {
       title: '',
       about: '',
-      url:   '',
+      url: '',
       anotherReadOnly: {
         test: 'hello'
       }
@@ -92,7 +92,7 @@ describe('serialize', ()=> {
     expect(serializedItem.attributes.anotherReadOnly).to.be(undefined)
   })
 
-  it('should serialize collections of items', ()=> {
+  it('should serialize collections of items', () => {
     jsonApi.define('product', {
       title: '',
       about: ''
@@ -108,21 +108,22 @@ describe('serialize', ()=> {
     expect(serializedItems[1].attributes.about).to.eql('two')
   })
 
-  it('should serialize the id of items if present', ()=> {
+  it('should serialize the id of items if present', () => {
     jsonApi.define('product', {title: ''})
     let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello'})
     expect(serializedItem.type).to.eql('products')
     expect(serializedItem.id).to.eql('5')
   })
 
-  it('should allow for custom serialization if present on the model', ()=> {
-    jsonApi.define('product', {title: ''}, {serializer: ()=> {
-      return {
-        custom: true
+  it('should allow for custom serialization if present on the model', () => {
+    jsonApi.define('product', {title: ''}, {
+      serializer: () => {
+        return {
+          custom: true
+        }
       }
-    }})
+    })
     let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello'})
     expect(serializedItem.custom).to.eql(true)
   })
-
 })

--- a/test/helpers/mock-response.js
+++ b/test/helpers/mock-response.js
@@ -1,8 +1,8 @@
-export default function(jsonApi, res = {}) {
+export default function (jsonApi, res = {}) {
   jsonApi.middleware.unshift({
     name: 'mock-response',
-    req: (payload)=> {
-      payload.req.adapter = function(resolve) {
+    req: (payload) => {
+      payload.req.adapter = function (resolve) {
         resolve(res)
       }
       return payload


### PR DESCRIPTION
## Priority
Yes, this fixed a bug where builder's destroy() was being redefined later on in the code. Standard was able to catch this.

## Screenshot
[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)

## What Changed & Why
Use standard for code style, why not?

## Testing
- npm test will fail if not up to standard

## Bug/Ticket Tracker
N/A

## Documentation
N/A

## In Progress/Follow Up
N/A

## Legal/Security/Privacy
N/A

## Third-Party
N/A

## People
@Emerson 