### PR TITLE
Added NPM prepublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 coverage
 .idea
+lib/

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ let post = jsonApi.findAll('post', {include: 'comments'})
 
 Devour uses a fully middleware based approach. This allows you to easily manipulate any part of the request and response cycle by injecting your own middleware. In fact, it's entirely possible to fully remove our default middleware and write your own. Moving forward we hope to see adapters for different server implementations. If you'd like to take a closer look at the middleware layer, please checkout:
 
-* The [index.js file](https://github.com/twg/devour-jsonapi-client/blob/master/index.js#L8) where we construct our default middleware stack
-* The middleware folder that contains all our default [JSON API middleware](https://github.com/twg/devour-jsonapi-client/tree/master/middleware/json-api)
+* The [index.js file](https://github.com/twg/devour/blob/master/index.js#L8) where we construct our default middleware stack
+* The middleware folder that contains all our default [JSON API middleware](https://github.com/twg/devour/tree/master/middleware/json-api)
 
 ### Your First Middleware
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "devour-client",
   "version": "1.0.5",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
-  "main": "index.js",
+  "main": "lib/",
   "scripts": {
+    "prepublish": "npm run compile",
+    "publish": "git push origin && git push origin --tags",
+    "release:patch": "npm version patch && npm publish",
+    "release:minor": "npm version minor && npm publish",
+    "release:major": "npm version major && npm publish",
+    "compile": "rm -rf lib/ && babel -d lib/ index.js",
+    "watch": "babel --watch -d lib/ index.js",
     "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "compile": "rm -rf lib/ && babel -d lib/ index.js",
-    "watch": "babel --watch -d lib/ index.js",
+    "compile": "rm -rf lib/ && ./node_modules/.bin/babel -d lib/ index.js",
+    "watch": "./node_modules/.bin/babel --watch -d lib/ index.js",
     "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha"
   },
   "repository": {
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/twg/devour-jsonapi-client#readme",
   "devDependencies": {
+    "babel-cli": "^6.8.0",
     "babel-core": "^6.7.7",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "devour-client",
   "version": "1.0.5",
-  "description": "Don't just consume your JSON API, Devour it...",
+  "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/twg/devour-jsonapi-client/issues"
+    "url": "https://github.com/twg/devour/issues"
   },
   "babel": {
     "presets": [
       "es2015"
     ]
   },
-  "homepage": "https://github.com/twg/devour-jsonapi-client#readme",
+  "homepage": "https://github.com/twg/devour#readme",
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-core": "^6.7.7",


### PR DESCRIPTION
I've added a series of npm scripts to `package.json`, most importantly a prepublish step that runs our source through Babel.

NPM scripts:

* prepublish
* publish
* release:patch
* release:minor
* release:major
* compile
* watch
* test
