### PR TITLE
added links to response object

### DIFF
--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -32,8 +32,11 @@ module.exports = {
       }
     }
 
-    if (res && res.meta) {
-      deserializedResponse.meta = res.meta
+    if (res) {
+      var params = ['meta', 'links']
+      params.forEach(function (param) {
+        deserializedResponse[param] = res[param]
+      })
     }
 
     return deserializedResponse


### PR DESCRIPTION
## Priority
Medium

## What Changed & Why
<img width="512" alt="screen_shot_2016-05-09_at_9_32_42_pm" src="https://cloud.githubusercontent.com/assets/1360097/15133076/b1b99ede-162d-11e6-86b3-c065536be417.png">
The response object can contain a `links` property, however, this property was not available on the collection after running through Devour's deserializer (the `meta` property was being carried over correctly though). 