### PR TITLE
Improve deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ jsonApi.define('product', {
   collectionPath: 'awesome-products',
   serializer: (rawItem)=> {
     return {customStuff: true}
+  },
+  deserializer: (rawItem)=> {
+    return {customStuff: true}
   }
 })
 ```

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -13,8 +13,11 @@ function resource (item, included, responseModel) {
     throw new Error('The JSON API response had a type of "' + item.type + '" but Devour expected the type to be "' + responseModel + '".')
   }
 
-  let deserializedModel = {}
+  if (model.options.deserializer) {
+    return model.options.deserializer.call(this, item)
+  }
 
+  let deserializedModel = {}
   if (item.id) {
     deserializedModel.id = item.id
   }
@@ -26,6 +29,14 @@ function resource (item, included, responseModel) {
       deserializedModel[key] = item.attributes[key]
     }
   })
+
+  var params = ['meta', 'links']
+  params.forEach(function (param) {
+    if (item[param]) {
+      deserializedModel[param] = item[param]
+    }
+  })
+
   return deserializedModel
 }
 

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -22,6 +22,12 @@ describe('deserialize', () => {
         attributes: {
           'title': 'Some Title',
           'about': 'Some about'
+        },
+        meta: {
+          info: 'Some meta data'
+        },
+        links: {
+          arbitrary: 'arbitrary link'
         }
       }
     }
@@ -29,6 +35,8 @@ describe('deserialize', () => {
     expect(product.id).to.eql('1')
     expect(product.title).to.eql('Some Title')
     expect(product.about).to.eql('Some about')
+    expect(product.meta.info).to.eql('Some meta data')
+    expect(product.links.arbitrary).to.eql('arbitrary link')
   })
 
   it('should deserialize hasMany relations', () => {
@@ -105,5 +113,60 @@ describe('deserialize', () => {
     expect(products[1].id).to.eql('2')
     expect(products[1].title).to.eql('Another Title')
     expect(products[1].about).to.eql('Another about')
+  })
+
+  it('should allow for custom deserialization if present on the resource definition', () => {
+    jsonApi.define('product', {title: ''}, {
+      deserializer: (rawItem) => {
+        return {
+          custom: true
+        }
+      }
+    })
+    let mockResponse = {
+      data: {
+        id: '1',
+        type: 'products',
+        attributes: {
+          title: 'Some Title',
+          about: 'Some about'
+        }
+      }
+    }
+    let product = deserialize.resource.call(jsonApi, mockResponse.data)
+    expect(product.custom).to.eql(true)
+  })
+
+  it('uses custom deserialization for each resource in a collection', () => {
+    jsonApi.define('product', {title: ''}, {
+      deserializer: () => {
+        return {
+          custom: true
+        }
+      }
+    })
+    let mockResponse = {
+      data: [
+        {
+          id: '1',
+          type: 'products',
+          attributes: {
+            title: 'Some Title',
+            about: 'Some about'
+          }
+        },
+        {
+          id: '2',
+          type: 'products',
+          attributes: {
+            title: 'Another Title',
+            about: 'Another about'
+          }
+        }
+      ]
+    }
+    let products = deserialize.collection.call(jsonApi, mockResponse.data)
+    expect(products[0].custom).to.eql(true)
+    expect(products[1].custom).to.eql(true)
   })
 })


### PR DESCRIPTION
## Priority
Currently blocked using this library as parsing of resources skips meta and links members. We also have some funky deserialization requirements that require the ability to specify a custom deserializer for a resource.

## What Changed & Why
1. **Resource deserialization will now include resource level meta and links objects.**
    The specification indicates that the top level document may contain an 'included' member which is an array of resource objects. Resource objects are further defined to allow inclusion of meta and links information. References linked in the Documentation section of this PR.

2. **Resource definition via jsonApi.define now accepts a deserializer option for custom deserialization**
    This is added to support some custom deserialization needs for client work, and it adds parity with the serializer option currently available when defining a resource.

3. **README has been updated to show deserializer option.**

## Testing

Tests have been added to test/api/deserialize-test.js to cover for deserializer option and default deserialization of meta and links members on resources.

### Custom deserializer:
Any resource defined with a deserializer option will use the specified function for deserializing that resource type.
```
jsonApi.define('product', {title: ''}, {
  deserializer: (rawItem) => {
    return {
      custom: true
    }
  }
})
```

A response defined as follows:
```
data: {
        id: '1',
        type: 'products',
        attributes: {
          title: 'Some Title',
          about: 'Some about'
        }
      }
    }
```

Would deserialize to:

```
{
  custom: true
}
```

### Default Resource Deserialization

A response defined as follows:

```
data: {
  id: '1',
  type: 'products',
  attributes: {
    'title': 'Some Title',
    'about': 'Some about'
  },
  meta: {
    info: 'Some meta data'
  },
  links: {
    arbitrary: 'arbitrary link'
  }
}
```

Will deserialize to:

```
{
  id: '1',
  title: 'Some Title',
  about: 'Some about',
  meta: {
    info: 'Some meta data'
  },
  links: {
    arbitrary: 'arbitrary link'
  }
}
```
## Bug/Ticket Tracker
Looks like some consideration has already been given to allowing a custom deserializer.
[Issue](https://github.com/twg/devour/issues/6#issuecomment-217915941)

## Documentation
[JSONAPI Resource Spec](http://jsonapi.org/format/#document-resource-objects) defining meta and links members on resource.

[JSONAPI Top Level Document ](http://jsonapi.org/format/#document-top-level) defining included as an array of resource objects.

