### PR TITLE
Serializer handles null/unspecified relationships

### DIFF
--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -31,7 +31,11 @@ function resource (modelName, item) {
 
   serializedResource.type = typeName
   serializedResource.attributes = serializedAttributes
-  serializedResource.relationships = serializedRelationships
+
+  if (Object.keys(serializedRelationships).length > 0) {
+    serializedResource.relationships = serializedRelationships
+  }
+
   if (item.id) {
     serializedResource.id = item.id
   }
@@ -47,10 +51,10 @@ function isRelationship (attribute) {
 }
 
 function serializeRelationship (relationshipName, relationship, relationshipType, serializeRelationships) {
-  if (relationshipType.jsonApi === 'hasMany') {
+  if (relationshipType.jsonApi === 'hasMany' && relationship !== undefined) {
     serializeRelationships[relationshipName] = serializeHasMany(relationship, relationshipType.type)
   }
-  if (relationshipType.jsonApi === 'hasOne') {
+  if (relationshipType.jsonApi === 'hasOne' && relationship !== undefined) {
     serializeRelationships[relationshipName] = serializeHasOne(relationship, relationshipType.type)
   }
 }
@@ -64,8 +68,8 @@ function serializeHasMany (relationships, type) {
 }
 
 function serializeHasOne (relationship, type) {
-  if (!relationship) {
-    return null
+  if (relationship === null) {
+    return {data: null}
   }
   return {
     data: {id: relationship.id, type: type}

--- a/test/api/serialize-test.js
+++ b/test/api/serialize-test.js
@@ -51,6 +51,125 @@ describe('serialize', () => {
     expect(serializedItem.relationships.tags.data[2].type).to.eql('tags')
   })
 
+  it('should not serialize omitted relationships', () => {
+    jsonApi.define('product', {
+      title: '',
+      about: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tags'
+      },
+      category: {
+        jsonApi: 'hasOne',
+        type: 'categories'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+    jsonApi.define('category', {
+      name: ''
+    })
+
+    let product = {
+      title: 'hello',
+      about: 'relationships',
+      tags: [
+        {id: 1, name: 'red'}
+      ]
+    }
+    let serializedItem = serialize.resource.call(jsonApi, 'product', product)
+    expect(serializedItem).to.have.property('relationships')
+    expect(serializedItem.relationships.tags.data).to.be.an('array')
+    expect(serializedItem.relationships.tags.data[0].id).to.eql(1)
+    expect(serializedItem.relationships.tags.data[0].type).to.eql('tags')
+
+    expect(serializedItem.relationships).to.not.have.property('category')
+  })
+
+  it('should omit the relationship object if none are specified', () => {
+    jsonApi.define('product', {
+      title: '',
+      about: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tags'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+
+    let product = {
+      title: 'hello',
+      about: 'relationships'
+    }
+
+    let serializedItem = serialize.resource.call(jsonApi, 'product', product)
+    expect(serializedItem).not.to.have.property('relationships')
+  })
+
+  it('should serialize null hasOne relationships', () => {
+    jsonApi.define('product', {
+      title: '',
+      about: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tags'
+      },
+      category: {
+        jsonApi: 'hasOne',
+        type: 'categories'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+    jsonApi.define('category', {
+      name: ''
+    })
+
+    let product = {
+      title: 'hello',
+      about: 'relationships',
+      category: null
+    }
+    let serializedItem = serialize.resource.call(jsonApi, 'product', product)
+    expect(serializedItem).to.have.property('relationships')
+    expect(serializedItem.relationships.category.data).to.eql(null)
+  })
+
+  it('should serialize empty hasMany relationships', () => {
+    jsonApi.define('product', {
+      title: '',
+      about: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tags'
+      },
+      category: {
+        jsonApi: 'hasOne',
+        type: 'categories'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+    jsonApi.define('category', {
+      name: ''
+    })
+
+    let product = {
+      title: 'hello',
+      about: 'relationships',
+      tags: []
+    }
+    let serializedItem = serialize.resource.call(jsonApi, 'product', product)
+    expect(serializedItem).to.have.property('relationships')
+    expect(serializedItem.relationships.tags.data).to.be.an('array')
+    expect(serializedItem.relationships.tags.data.length).to.eql(0)
+  })
+
   it('should serialize hasOne relationships', () => {
     jsonApi.define('product', {
       title: '',


### PR DESCRIPTION
## Priority
Merging sooner rather than later would be ideal (pending discussion/approval, obviously), as this is relied on in production.

## What Changed & Why
Alters the behaviour around serializing unspecified/null/empty relationships as per the description in #29 - the tests included in this PR describe the changes in detail, but the summary is:

- unspecified relationships are not serialized
- hasOne relationships that are deliberately set to null are serialized correctly
- hasMany relationships that are deliberately set to empty arrays are serialized correctly
- relationship object is omitted if no relationships are specified at all