### PR TITLE
Support arbitrary requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ jsonApi.update('post', {
 
 // To destroy...
 jsonApi.destroy('post', 5)
+
+// To make arbitrary requests through the middleware stack
+jsonApi.request('https://example.com', 'GET', { a_query_param: 3 }, { some_payload_item: 'blah' })
 ```
 
 ### Initializer

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "1.0.0-alpha.2",
     "mocha": "^2.4.5",
+    "sinon": "^1.17.4",
     "standard": "^7.0.1"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -261,6 +261,11 @@ class JsonApi {
       })
   }
 
+  request (url, method = 'GET', params = {}, data = {}) {
+    let req = { url, method, params, data }
+    return this.runMiddleware(req)
+  }
+
   find (modelName, id, params = {}) {
     let req = {
       method: 'GET',

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -3,6 +3,7 @@
 import JsonApi from '../../src/index'
 import mockResponse from '../helpers/mock-response'
 import expect from 'expect.js'
+import sinon from 'sinon'
 
 describe('JsonApi', () => {
   var jsonApi = null
@@ -302,6 +303,20 @@ describe('JsonApi', () => {
         expect(products[0].title).to.eql('Some Title')
         done()
       }).catch(err => console.log(err))
+    })
+
+    it('should expose a method for arbitrary HTTP calls', () => {
+      const url = 'https://example.com'
+      const method = 'PATCH'
+      const params = { id: 3 }
+      const data = { body: 'something different' }
+
+      jsonApi.runMiddleware = sinon.spy()
+
+      jsonApi.request(url, method, params, data)
+
+      expect(jsonApi.runMiddleware.called).to.be.truthy
+      expect(jsonApi.runMiddleware.calledWith(url, method, params, data)).to.be.truthy
     })
   })
 


### PR DESCRIPTION
## What Changed & Why
The rationale behind this is that pagination links (and other linked resources) are something that is fairly commonplace, however devour does not currently implement any feature that allows consumers to follow those links, which requires (for example) manual management of pagination parameters and construction of related resource URLs using the builder.

This PR introduces `request`—a very thin wrapper around `runMiddleware`, primarily to have something documented that allows arbitrary requests to be made through the middleware stack.

This might require a bit of discussion as it omits the model part of the request that would normally be present on requests. I'm not sure what side effects this might have, but in my in-app testing it hasn't caused any notable issues.