### PR TITLE
Use lodash.assign over Object.assign

### DIFF
--- a/src/middleware/json-api/req-headers.js
+++ b/src/middleware/json-api/req-headers.js
@@ -1,10 +1,11 @@
 const isEmpty = require('lodash').isEmpty
+const assign = require('lodash').assign
 
 module.exports = {
   name: 'HEADER',
   req: (payload) => {
     if (!isEmpty(payload.jsonApi.headers)) {
-      payload.req.headers = Object.assign({}, payload.req.headers, payload.jsonApi.headers)
+      payload.req.headers = assign({}, payload.req.headers, payload.jsonApi.headers)
     }
     return payload
   }


### PR DESCRIPTION
## What Changed & Why
Use lodash's version of `assign` over `Object.assign`.

While this can be polyfilled as mentioned in #40, there's precedent for use of lodash's `assign` already in the project (in [index.js](https://github.com/twg/devour/blob/master/src/index.js#L67)).

Given this is a pretty simple change and doesn't introduce any extra dependencies, I think it's worth doing this to avoid the polyfill requirement in older browsers.