### PR TITLE
pass relationship key explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "lib/",
   "scripts": {

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -24,7 +24,7 @@ function resource (item, included, responseModel) {
 
   _.forOwn(model.attributes, (value, key) => {
     if (isRelationship(value)) {
-      deserializedModel[key] = attachRelationsFor.call(this, model, value, item, included)
+      deserializedModel[key] = attachRelationsFor.call(this, model, value, item, included, key)
     } else {
       deserializedModel[key] = item.attributes[key]
     }
@@ -40,22 +40,22 @@ function resource (item, included, responseModel) {
   return deserializedModel
 }
 
-function attachRelationsFor (model, attribute, item, included) {
+function attachRelationsFor (model, attribute, item, included, key) {
   let relation = null
   if (attribute.jsonApi === 'hasOne') {
-    relation = attachHasOneFor.call(this, model, attribute, item, included)
+    relation = attachHasOneFor.call(this, model, attribute, item, included, key)
   }
   if (attribute.jsonApi === 'hasMany') {
-    relation = attachHasManyFor.call(this, model, attribute, item, included)
+    relation = attachHasManyFor.call(this, model, attribute, item, included, key)
   }
   return relation
 }
 
-function attachHasOneFor (model, attribute, item, included) {
+function attachHasOneFor (model, attribute, item, included, key) {
   if (!item.relationships) {
     return null
   }
-  let relatedItems = relatedItemsFor(model, attribute, item, included)
+  let relatedItems = relatedItemsFor(model, attribute, item, included, key)
   if (relatedItems && relatedItems[0]) {
     return resource.call(this, relatedItems[0], included)
   } else {
@@ -63,11 +63,11 @@ function attachHasOneFor (model, attribute, item, included) {
   }
 }
 
-function attachHasManyFor (model, attribute, item, included) {
+function attachHasManyFor (model, attribute, item, included, key) {
   if (!item.relationships) {
     return null
   }
-  let relatedItems = relatedItemsFor(model, attribute, item, included)
+  let relatedItems = relatedItemsFor(model, attribute, item, included, key)
   if (relatedItems && relatedItems.length > 0) {
     return collection.call(this, relatedItems, included)
   }
@@ -82,9 +82,8 @@ function isRelationship (attribute) {
  *   == relatedItemsFor
  *   Returns unserialized related items.
  */
-function relatedItemsFor (model, attribute, item, included) {
-  let relationName = _.findKey(model.attributes, attribute)
-  let relationMap = _.get(item.relationships, [relationName, 'data'], false)
+function relatedItemsFor (model, attribute, item, included, key) {
+  let relationMap = _.get(item.relationships, [key, 'data'], false)
   if (!relationMap) {
     return []
   }


### PR DESCRIPTION
## Priority
High - this PR is blocking me (though I can link to this specific branch for the time being)

## What Changed & Why
Given the following model:
```
api.define('jobItem', {
  haystackSilo: {
    jsonApi: 'hasOne',
    type: 'silos'
  },
  needleSilo: {
    jsonApi: 'hasOne',
    type: 'silos'
  }
})
```
Devour ends up overwriting the latter's data with the former. This is because Devour infers the key name based on the format of the attribute object. Specifically, this is defined here: https://github.com/twg/devour/blob/master/src/middleware/json-api/_deserialize.js#L86. `_.findKey` simply returns the *first* key where the attribute object matches. This means regardless of whether Devour is handling the haystackSilo relationship or the needleSilo relationship, the `relationshipName` will always be haystackSilo.

To address this, I simply explicitly passed the key down to this function, therefore `relatedItemsFor` no longer attempts to infer the key given a particular attribute.