### PR TITLE
Feature/post patch params

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,6 @@ let jsonApi = new JsonApi({apiUrl: 'http://api.yoursite.com'})
 jsonApi.define('author', {name: ''})
 jsonApi.define('post', {title: ''})
 
-jsonApi.one('author', 1).all('post').get({include: 'books'}) // GET http://api.yoursite.com/authors/1/posts
-jsonApi.one('author', 1).all('post').post({title:'title'}, {include: 'books'}) // POST http://api.yoursite.com/authors/1/posts
+jsonApi.one('author', 1).all('post').get({include: 'books'}) // GET http://api.yoursite.com/authors/1/posts?include=books
+jsonApi.one('author', 1).all('post').post({title:'title'}, {include: 'books'}) // POST http://api.yoursite.com/authors/1/posts?include=books
 ```

--- a/README.md
+++ b/README.md
@@ -181,6 +181,6 @@ let jsonApi = new JsonApi({apiUrl: 'http://api.yoursite.com'})
 jsonApi.define('author', {name: ''})
 jsonApi.define('post', {title: ''})
 
-jsonApi.one('author', 1).all('post').get() // GET http://api.yoursite.com/authors/1/posts
-jsonApi.one('author', 1).all('post').post({title:'title'}) // POST http://api.yoursite.com/authors/1/posts
+jsonApi.one('author', 1).all('post').get({include: 'books'}) // GET http://api.yoursite.com/authors/1/posts
+jsonApi.one('author', 1).all('post').post({title:'title'}, {include: 'books'}) // POST http://api.yoursite.com/authors/1/posts
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "lib/",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -127,14 +127,15 @@ class JsonApi {
     return this.runMiddleware(req)
   }
 
-  post (payload) {
+  post (payload, params = {}) {
     let lastRequest = _.chain(this.builderStack).last()
 
     let req = {
       method: 'POST',
       url: this.urlFor(),
       model: lastRequest.get('model').value(),
-      data: payload
+      data: payload,
+      params: params
     }
 
     if (this.resetBuilderOnCall) {
@@ -144,14 +145,15 @@ class JsonApi {
     return this.runMiddleware(req)
   }
 
-  patch (payload) {
+  patch (payload, params) {
     let lastRequest = _.chain(this.builderStack).last()
 
     let req = {
       method: 'PATCH',
       url: this.urlFor(),
       model: lastRequest.get('model').value(),
-      data: payload
+      data: payload,
+      params: params
     }
 
     if (this.resetBuilderOnCall) {


### PR DESCRIPTION
## Priority
This feature is blocking me (though I can point my project to this branch for the time being)

## What Changed & Why
I've run into an instance where I need to include a query param in a POST request. I realize this might not be a common requirement (in my case I wanted the response to include an expanded relationship) but Devour should allow for the option to include query params with any request.

Users could already include query params with GET requests:
`jsonApi.one('author', 1).all('post').get({include: 'books'})`

Now there is support for included query params in PATCH and POST requests as well (as an optional second param):
`jsonApi.one('author', 1).all('post').post({title:'title'}, {include: 'books'})`