### PR TITLE
Handle null primary data in deserializer

### DIFF
--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -28,12 +28,12 @@ module.exports = {
     if (status !== 204 && needsDeserialization(req.method)) {
       if (isCollection(res.data)) {
         deserializedResponse = deserialize.collection.call(jsonApi, res.data, included, req.model)
-      } else {
+      } else if (res.data) {
         deserializedResponse = deserialize.resource.call(jsonApi, res.data, included, req.model)
       }
     }
 
-    if (res) {
+    if (res && deserializedResponse) {
       var params = ['meta', 'links']
       params.forEach(function (param) {
         deserializedResponse[param] = res[param]

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -321,6 +321,21 @@ describe('JsonApi', () => {
       expect(jsonApi.runMiddleware.calledWith(url, method, params, data)).to.be.truthy
     })
 
+    it('should handle null primary data', (done) => {
+      mockResponse(jsonApi, {
+        data: {
+          data: null
+        }
+      })
+      jsonApi.define('product', {
+        title: ''
+      })
+      jsonApi.find('product', 1).then((product) => {
+        expect(product).to.eql(null)
+        done()
+      }).catch(err => console.log(err))
+    })
+
     it('should have an empty body on GET requests', (done) => {
       let inspectorMiddleware = {
         name: 'inspector-middleware',


### PR DESCRIPTION
## What Changed & Why
When requesting a single resource and that resource is null i.e. the response is as below

```json
{
  "data": null
}
```
then the library would throw an error when attempting to deserialize this null data.

To address this I added a couple of checks that guard against this case.

[Related section in the spec](http://jsonapi.org/format/#document-top-level) (see the description of primary data)