### PR TITLE
fix deserialize resources without attributes

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -25,7 +25,7 @@ function resource (item, included, responseModel) {
   _.forOwn(model.attributes, (value, key) => {
     if (isRelationship(value)) {
       deserializedModel[key] = attachRelationsFor.call(this, model, value, item, included, key)
-    } else {
+    } else if (item.attributes) {
       deserializedModel[key] = item.attributes[key]
     }
   })

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -169,4 +169,74 @@ describe('deserialize', () => {
     expect(products[0].custom).to.eql(true)
     expect(products[1].custom).to.eql(true)
   })
+
+  it('should deserialize resources in data without attributes', () => {
+    jsonApi.define('product', {
+      title: '',
+      about: ''
+    })
+    let mockResponse = {
+      data: [
+        {
+          id: '1',
+          type: 'products'
+        },
+        {
+          id: '2',
+          type: 'products',
+          attributes: {
+            title: 'Another Title',
+            about: 'Another about'
+          }
+        }
+      ]
+    }
+    let products = deserialize.collection.call(jsonApi, mockResponse.data)
+    expect(products[0].title).to.be.undefined
+    expect(products[0].about).to.be.undefined
+    expect(products[1].title).to.be.eql('Another Title')
+    expect(products[1].about).to.be.eql('Another about')
+  })
+
+  it('should deserialize resources in include without attributes', () => {
+    jsonApi.define('product', {
+      title: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tags'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+    let mockResponse = {
+      data: {
+        id: '1',
+        type: 'products',
+        attributes: {
+          title: 'hello'
+        },
+        relationships: {
+          tags: {
+            data: [
+            {id: '5', type: 'tags'},
+            {id: '6', type: 'tags'}
+            ]
+          }
+        }
+      },
+      included: [
+      {id: '5', type: 'tags'},
+      {id: '6', type: 'tags', attributes: {name: 'two'}}
+      ]
+    }
+    let product = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
+    expect(product.id).to.eql('1')
+    expect(product.title).to.eql('hello')
+    expect(product.tags).to.be.an('array')
+    expect(product.tags[0].id).to.eql('5')
+    expect(product.tags[0].name).to.be.undefined
+    expect(product.tags[1].id).to.eql('6')
+    expect(product.tags[1].name).to.eql('two')
+  })
 })


### PR DESCRIPTION
## What Changed & Why
According with the `JSON API` definition, a resource object MAY contain `attributes`.
http://jsonapi.org/format/#document-resource-objects
```
In addition, a resource object MAY contain any of these top-level members:
  - attributes: an attributes object representing some of the resource’s data.
  - relationships: a relationships object describing relationships between the resource and other JSON API resources.
  - links: a links object containing links related to the resource.
  - meta: a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship.
```
So, what I did is just checking if `attributes` is defined in the response resource object, before trying to access its properties.