### PR TITLE
Adding check for params during deserialization

### DIFF
--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -36,7 +36,9 @@ module.exports = {
     if (res && deserializedResponse) {
       var params = ['meta', 'links']
       params.forEach(function (param) {
-        deserializedResponse[param] = res[param]
+        if (res[param]) {
+          deserializedResponse[param] = res[param]
+        }
       })
     }
 


### PR DESCRIPTION
## What Changed & Why
Our API doesn't include "meta" items for some entities.
JSON API spec mentions that this is optional: http://jsonapi.org/format/#document-meta

Line 35 of _deserialize.js checks if param exists before assigning:
https://github.com/twg/devour/blob/master/src/middleware/json-api/_deserialize.js#L35

This PR just adds the same check to res-deserialize.js.
