### PR TITLE
add type property to deserialized resource

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -22,6 +22,10 @@ function resource (item, included, responseModel) {
     deserializedModel.id = item.id
   }
 
+  if (item.type) {
+    deserializedModel.type = item.type
+  }
+
   _.forOwn(model.attributes, (value, key) => {
     if (isRelationship(value)) {
       deserializedModel[key] = attachRelationsFor.call(this, model, value, item, included, key)

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -33,6 +33,7 @@ describe('deserialize', () => {
     }
     let product = deserialize.resource.call(jsonApi, mockResponse.data)
     expect(product.id).to.eql('1')
+    expect(product.type).to.eql('products')
     expect(product.title).to.eql('Some Title')
     expect(product.about).to.eql('Some about')
     expect(product.meta.info).to.eql('Some meta data')
@@ -73,11 +74,14 @@ describe('deserialize', () => {
     }
     let product = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
     expect(product.id).to.eql('1')
+    expect(product.type).to.eql('products')
     expect(product.title).to.eql('hello')
     expect(product.tags).to.be.an('array')
     expect(product.tags[0].id).to.eql('5')
+    expect(product.tags[0].type).to.eql('tags')
     expect(product.tags[0].name).to.eql('one')
     expect(product.tags[1].id).to.eql('6')
+    expect(product.tags[1].type).to.eql('tags')
     expect(product.tags[1].name).to.eql('two')
   })
 
@@ -108,9 +112,11 @@ describe('deserialize', () => {
     }
     let products = deserialize.collection.call(jsonApi, mockResponse.data)
     expect(products[0].id).to.eql('1')
+    expect(products[0].type).to.eql('products')
     expect(products[0].title).to.eql('Some Title')
     expect(products[0].about).to.eql('Some about')
     expect(products[1].id).to.eql('2')
+    expect(products[1].type).to.eql('products')
     expect(products[1].title).to.eql('Another Title')
     expect(products[1].about).to.eql('Another about')
   })


### PR DESCRIPTION
## Priority
Yes, to be able to parse polymorphic relationships and give back the specific type of it

## What Changed & Why
When a `resource` is deserialized, I just added the `type` of the received data in the returned `object`.

The reason is that the `name` of the `attribute` used for the `relationship` in some case (`polymorphic relationship`) does not match with the type of data itself.
Example: http://jsonapi.org/format/#document-resource-object-relationships (look the example they wrote `relationship: author` -> `type: 'people'`)
So to be able to know the specific type of the `relationship` I need to have the `type` of the `attribute` in the `deserialized object`