### PR TITLE
BUGFIX infinite loop on deserializing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /node_modules
 coverage
 .idea
-lib/

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,421 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var axios = require('axios');
+var pluralize = require('pluralize');
+var _ = require('lodash');
+var Promise = require('es6-promise').Promise;
+var deserialize = require('./middleware/json-api/_deserialize');
+var serialize = require('./middleware/json-api/_serialize');
+var Minilog = require('minilog');
+
+/*
+ *   == JsonApiMiddleware
+ *
+ *   Here we construct the middleware stack that will handle building and making
+ *   requests, as well as serializing and deserializing our payloads. Users can
+ *   easily construct their own middleware layers that adhere to different
+ *   standards.
+ *
+ */
+var jsonApiHttpBasicAuthMiddleware = require('./middleware/json-api/req-http-basic-auth');
+var jsonApiPostMiddleware = require('./middleware/json-api/req-post');
+var jsonApiPatchMiddleware = require('./middleware/json-api/req-patch');
+var jsonApiDeleteMiddleware = require('./middleware/json-api/req-delete');
+var jsonApiGetMiddleware = require('./middleware/json-api/req-get');
+var jsonApiHeadersMiddleware = require('./middleware/json-api/req-headers');
+var railsParamsSerializer = require('./middleware/json-api/rails-params-serializer');
+var sendRequestMiddleware = require('./middleware/request');
+var deserializeResponseMiddleware = require('./middleware/json-api/res-deserialize');
+var processErrors = require('./middleware/json-api/res-errors');
+
+var jsonApiMiddleware = [jsonApiHttpBasicAuthMiddleware, jsonApiPostMiddleware, jsonApiPatchMiddleware, jsonApiDeleteMiddleware, jsonApiGetMiddleware, jsonApiHeadersMiddleware, railsParamsSerializer, sendRequestMiddleware, processErrors, deserializeResponseMiddleware];
+
+var JsonApi = function () {
+  function JsonApi() {
+    var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+    _classCallCheck(this, JsonApi);
+
+    if (!(arguments.length === 2 && _.isString(arguments[0]) && _.isArray(arguments[1])) && !(arguments.length === 1 && (_.isPlainObject(arguments[0]) || _.isString(arguments[0])))) {
+      throw new Error('Invalid argument, initialize Devour with an object.');
+    }
+
+    var defaults = {
+      middleware: jsonApiMiddleware,
+      logger: true,
+      resetBuilderOnCall: true,
+      auth: {}
+    };
+
+    var deprecatedConstructos = function deprecatedConstructos(args) {
+      return args.length === 2 || args.length === 1 && _.isString(args[0]);
+    };
+
+    if (deprecatedConstructos(arguments)) {
+      defaults.apiUrl = arguments[0];
+      if (arguments.length === 2) {
+        defaults.middleware = arguments[1];
+      }
+    }
+
+    options = _.assign(defaults, options);
+    var middleware = options.middleware;
+
+    this._originalMiddleware = middleware.slice(0);
+    this.middleware = middleware.slice(0);
+    this.headers = {};
+    this.axios = axios;
+    this.auth = options.auth;
+    this.apiUrl = options.apiUrl;
+    this.models = {};
+    this.deserialize = deserialize;
+    this.serialize = serialize;
+    this.builderStack = [];
+    this.resetBuilderOnCall = !!options.resetBuilderOnCall;
+    this.logger = Minilog('devour');
+    options.logger ? Minilog.enable() : Minilog.disable();
+
+    if (deprecatedConstructos(arguments)) {
+      this.logger.warn('Constructor (apiUrl, middleware) has been deprecated, initialize Devour with an object.');
+    }
+  }
+
+  _createClass(JsonApi, [{
+    key: 'enableLogging',
+    value: function enableLogging() {
+      var enabled = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+
+      enabled ? Minilog.enable() : Minilog.disable();
+    }
+  }, {
+    key: 'one',
+    value: function one(model, id) {
+      this.builderStack.push({ model: model, id: id, path: this.resourcePathFor(model, id) });
+      return this;
+    }
+  }, {
+    key: 'all',
+    value: function all(model) {
+      this.builderStack.push({ model: model, path: this.collectionPathFor(model) });
+      return this;
+    }
+  }, {
+    key: 'resetBuilder',
+    value: function resetBuilder() {
+      this.builderStack = [];
+    }
+  }, {
+    key: 'buildPath',
+    value: function buildPath() {
+      return _.map(this.builderStack, 'path').join('/');
+    }
+  }, {
+    key: 'buildUrl',
+    value: function buildUrl() {
+      return this.apiUrl + '/' + this.buildPath();
+    }
+  }, {
+    key: 'get',
+    value: function get() {
+      var params = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+      var req = {
+        method: 'GET',
+        url: this.urlFor(),
+        data: {},
+        params: params
+      };
+
+      if (this.resetBuilderOnCall) {
+        this.resetBuilder();
+      }
+
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'post',
+    value: function post(payload) {
+      var params = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+      var lastRequest = _.chain(this.builderStack).last();
+
+      var req = {
+        method: 'POST',
+        url: this.urlFor(),
+        model: lastRequest.get('model').value(),
+        data: payload,
+        params: params
+      };
+
+      if (this.resetBuilderOnCall) {
+        this.resetBuilder();
+      }
+
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'patch',
+    value: function patch(payload) {
+      var params = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+      var lastRequest = _.chain(this.builderStack).last();
+
+      var req = {
+        method: 'PATCH',
+        url: this.urlFor(),
+        model: lastRequest.get('model').value(),
+        data: payload,
+        params: params
+      };
+
+      if (this.resetBuilderOnCall) {
+        this.resetBuilder();
+      }
+
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'destroy',
+    value: function destroy() {
+      if (arguments.length === 2) {
+        var req = {
+          method: 'DELETE',
+          url: this.urlFor({ model: arguments[0], id: arguments[1] }),
+          model: arguments[0],
+          data: {}
+        };
+        return this.runMiddleware(req);
+      } else {
+        var lastRequest = _.chain(this.builderStack).last();
+
+        var _req = {
+          method: 'DELETE',
+          url: this.urlFor(),
+          model: lastRequest.get('model').value(),
+          data: {}
+        };
+
+        if (this.resetBuilderOnCall) {
+          this.resetBuilder();
+        }
+
+        return this.runMiddleware(_req);
+      }
+    }
+  }, {
+    key: 'insertMiddlewareBefore',
+    value: function insertMiddlewareBefore(middlewareName, newMiddleware) {
+      this.insertMiddleware(middlewareName, 'before', newMiddleware);
+    }
+  }, {
+    key: 'insertMiddlewareAfter',
+    value: function insertMiddlewareAfter(middlewareName, newMiddleware) {
+      this.insertMiddleware(middlewareName, 'after', newMiddleware);
+    }
+  }, {
+    key: 'insertMiddleware',
+    value: function insertMiddleware(middlewareName, direction, newMiddleware) {
+      var middleware = this.middleware.filter(function (middleware) {
+        return middleware.name === middlewareName;
+      });
+      if (middleware.length > 0) {
+        var index = this.middleware.indexOf(middleware[0]);
+        if (direction === 'after') {
+          index = index + 1;
+        }
+        this.middleware.splice(index, 0, newMiddleware);
+      }
+    }
+  }, {
+    key: 'define',
+    value: function define(modelName, attributes) {
+      var options = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+
+      this.models[modelName] = {
+        attributes: attributes,
+        options: options
+      };
+    }
+  }, {
+    key: 'resetMiddleware',
+    value: function resetMiddleware() {
+      this.middleware = this._originalMiddleware.slice(0);
+    }
+  }, {
+    key: 'applyRequestMiddleware',
+    value: function applyRequestMiddleware(promise) {
+      var requestMiddlewares = this.middleware.filter(function (middleware) {
+        return middleware.req;
+      });
+      requestMiddlewares.forEach(function (middleware) {
+        promise = promise.then(middleware.req);
+      });
+      return promise;
+    }
+  }, {
+    key: 'applyResponseMiddleware',
+    value: function applyResponseMiddleware(promise) {
+      var responseMiddleware = this.middleware.filter(function (middleware) {
+        return middleware.res;
+      });
+      responseMiddleware.forEach(function (middleware) {
+        promise = promise.then(middleware.res);
+      });
+      return promise;
+    }
+  }, {
+    key: 'applyErrorMiddleware',
+    value: function applyErrorMiddleware(promise) {
+      var errorsMiddleware = this.middleware.filter(function (middleware) {
+        return middleware.error;
+      });
+      errorsMiddleware.forEach(function (middleware) {
+        promise = promise.then(middleware.error);
+      });
+      return promise;
+    }
+  }, {
+    key: 'runMiddleware',
+    value: function runMiddleware(req) {
+      var _this = this;
+
+      var payload = { req: req, jsonApi: this };
+      var requestPromise = Promise.resolve(payload);
+      requestPromise = this.applyRequestMiddleware(requestPromise);
+      return requestPromise.then(function (res) {
+        payload.res = res;
+        var responsePromise = Promise.resolve(payload);
+        return _this.applyResponseMiddleware(responsePromise);
+      }).catch(function (err) {
+        _this.logger.error(err);
+        var errorPromise = Promise.resolve(err);
+        return _this.applyErrorMiddleware(errorPromise).then(function (err) {
+          return Promise.reject(err);
+        });
+      });
+    }
+  }, {
+    key: 'request',
+    value: function request(url) {
+      var method = arguments.length <= 1 || arguments[1] === undefined ? 'GET' : arguments[1];
+      var params = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+      var data = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
+
+      var req = { url: url, method: method, params: params, data: data };
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'find',
+    value: function find(modelName, id) {
+      var params = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+
+      var req = {
+        method: 'GET',
+        url: this.urlFor({ model: modelName, id: id }),
+        model: modelName,
+        data: {},
+        params: params
+      };
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'findAll',
+    value: function findAll(modelName) {
+      var params = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+      var req = {
+        method: 'GET',
+        url: this.urlFor({ model: modelName }),
+        model: modelName,
+        params: params,
+        data: {}
+      };
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'create',
+    value: function create(modelName, payload) {
+      var req = {
+        method: 'POST',
+        url: this.urlFor({ model: modelName }),
+        model: modelName,
+        data: payload
+      };
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'update',
+    value: function update(modelName, payload) {
+      var req = {
+        method: 'PATCH',
+        url: this.urlFor({ model: modelName, id: payload.id }),
+        model: modelName,
+        data: payload
+      };
+      return this.runMiddleware(req);
+    }
+  }, {
+    key: 'modelFor',
+    value: function modelFor(modelName) {
+      return this.models[modelName];
+    }
+  }, {
+    key: 'collectionPathFor',
+    value: function collectionPathFor(modelName) {
+      var collectionPath = _.get(this.models[modelName], 'options.collectionPath') || pluralize(modelName);
+      return '' + collectionPath;
+    }
+  }, {
+    key: 'resourcePathFor',
+    value: function resourcePathFor(modelName, id) {
+      var collectionPath = this.collectionPathFor(modelName);
+      return collectionPath + '/' + encodeURIComponent(id);
+    }
+  }, {
+    key: 'collectionUrlFor',
+    value: function collectionUrlFor(modelName) {
+      var collectionPath = this.collectionPathFor(modelName);
+      return this.apiUrl + '/' + collectionPath;
+    }
+  }, {
+    key: 'resourceUrlFor',
+    value: function resourceUrlFor(modelName, id) {
+      var resourcePath = this.resourcePathFor(modelName, id);
+      return this.apiUrl + '/' + resourcePath;
+    }
+  }, {
+    key: 'urlFor',
+    value: function urlFor() {
+      var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+      if (!_.isUndefined(options.model) && !_.isUndefined(options.id)) {
+        return this.resourceUrlFor(options.model, options.id);
+      } else if (!_.isUndefined(options.model)) {
+        return this.collectionUrlFor(options.model);
+      } else {
+        return this.buildUrl();
+      }
+    }
+  }, {
+    key: 'pathFor',
+    value: function pathFor() {
+      var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+      if (!_.isUndefined(options.model) && !_.isUndefined(options.id)) {
+        return this.resourcePathFor(options.model, options.id);
+      } else if (!_.isUndefined(options.model)) {
+        return this.collectionPathFor(options.model);
+      } else {
+        return this.buildPath();
+      }
+    }
+  }]);
+
+  return JsonApi;
+}();
+
+module.exports = JsonApi;

--- a/lib/middleware/json-api/_deserialize.js
+++ b/lib/middleware/json-api/_deserialize.js
@@ -1,0 +1,170 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _ = require('lodash');
+var pluralize = require('pluralize');
+
+var cache = new (function () {
+  function _class() {
+    _classCallCheck(this, _class);
+
+    this._cache = [];
+  }
+
+  _createClass(_class, [{
+    key: 'set',
+    value: function set(type, id, deserializedData) {
+      this._cache.push({
+        type: type,
+        id: id,
+        deserialized: deserializedData
+      });
+    }
+  }, {
+    key: 'get',
+    value: function get(type, id) {
+      var match = _.find(this._cache, function (r) {
+        return r.type === type && r.id === id;
+      });
+      return match && match.deserialized;
+    }
+  }]);
+
+  return _class;
+}())();
+
+function collection(items, included, responseModel) {
+  var _this = this;
+
+  var useCache = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
+
+  return items.map(function (item) {
+    return resource.call(_this, item, included, responseModel, useCache);
+  });
+}
+
+function resource(item, included, responseModel) {
+  var _this2 = this;
+
+  var useCache = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
+
+  if (useCache) {
+    var cachedItem = cache.get(item.type, item.id);
+    if (cachedItem) return cachedItem;
+  }
+
+  var model = this.modelFor(pluralize.singular(item.type));
+  if (!model) throw new Error('The JSON API response had a type of "' + item.type + '" but Devour expected the type to be "' + responseModel + '".');
+
+  if (model.options.deserializer) return model.options.deserializer.call(this, item);
+
+  var deserializedModel = { id: item.id };
+
+  _.forOwn(item.attributes, function (value, attr) {
+    var attrConfig = model.attributes[attr];
+
+    if (_.isUndefined(attrConfig) && attr !== "id") {
+      console.warn('Resource response contains attribute "' + attr + '", but it is not present on model config and therefore not deserialized.');
+    } else {
+      deserializedModel[attr] = value;
+    }
+  });
+
+  // Important: cache before parsing relationships to avoid infinite loop
+  cache.set(item.type, item.id, deserializedModel);
+
+  _.forOwn(item.relationships, function (value, rel) {
+    var relConfig = model.attributes[rel];
+
+    if (_.isUndefined(relConfig)) console.warn('Resource response contains relationship "' + rel + '", but it is not present on model config and therefore not deserialized.');else if (!isRelationship(relConfig)) console.warn('Resource response contains relationship "' + rel + '", but it is present on model config as a plain attribute.');else deserializedModel[rel] = attachRelationsFor.call(_this2, model, relConfig, item, included, rel);
+  });
+
+  var params = ['meta', 'links'];
+  params.forEach(function (param) {
+    if (item[param]) {
+      deserializedModel[param] = item[param];
+    }
+  });
+
+  cache.set(item.type, item.id, deserializedModel);
+
+  return deserializedModel;
+}
+
+function attachRelationsFor(model, attribute, item, included, key) {
+  var relation = null;
+  if (attribute.jsonApi === 'hasOne') {
+    relation = attachHasOneFor.call(this, model, attribute, item, included, key);
+  }
+  if (attribute.jsonApi === 'hasMany') {
+    relation = attachHasManyFor.call(this, model, attribute, item, included, key);
+  }
+  return relation;
+}
+
+function attachHasOneFor(model, attribute, item, included, key) {
+  if (!item.relationships) {
+    return null;
+  }
+
+  var relatedItems = relatedItemsFor(model, attribute, item, included, key);
+  if (relatedItems && relatedItems[0]) {
+    return resource.call(this, relatedItems[0], included, undefined, true);
+  } else {
+    return null;
+  }
+}
+
+function attachHasManyFor(model, attribute, item, included, key) {
+  if (!item.relationships) {
+    return null;
+  }
+  var relatedItems = relatedItemsFor(model, attribute, item, included, key);
+  if (relatedItems && relatedItems.length > 0) {
+    return collection.call(this, relatedItems, included, undefined, true);
+  }
+  return [];
+}
+
+function isRelationship(attribute) {
+  return _.isPlainObject(attribute) && _.includes(['hasOne', 'hasMany'], attribute.jsonApi);
+}
+
+/*
+ *   == relatedItemsFor
+ *   Returns unserialized related items.
+ */
+function relatedItemsFor(model, attribute, item, included, key) {
+  var relationMap = _.get(item.relationships, [key, 'data'], false);
+  if (!relationMap) {
+    return [];
+  }
+
+  if (_.isArray(relationMap)) {
+    return _.flatten(_.map(relationMap, function (relationMapItem) {
+      return _.filter(included, function (includedItem) {
+        return isRelatedItemFor(attribute, includedItem, relationMapItem);
+      });
+    }));
+  } else {
+    return _.filter(included, function (includedItem) {
+      return isRelatedItemFor(attribute, includedItem, relationMap);
+    });
+  }
+}
+
+function isRelatedItemFor(attribute, relatedItem, relationMapItem) {
+  var passesFilter = true;
+  if (attribute.filter) {
+    passesFilter = _.matches(relatedItem.attributes, attribute.filter);
+  }
+  return relatedItem.id === relationMapItem.id && relatedItem.type === relationMapItem.type && passesFilter;
+}
+
+module.exports = {
+  resource: resource,
+  collection: collection
+};

--- a/lib/middleware/json-api/_serialize.js
+++ b/lib/middleware/json-api/_serialize.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var _ = require('lodash');
+var pluralize = require('pluralize');
+
+function collection(modelName, items) {
+  var _this = this;
+
+  return items.map(function (item) {
+    return resource.call(_this, modelName, item);
+  });
+}
+
+function resource(modelName, item) {
+  var model = this.modelFor(modelName);
+  var options = model.options || {};
+  var readOnly = options.readOnly || [];
+  var typeName = options.type || pluralize(modelName);
+  var serializedAttributes = {};
+  var serializedRelationships = {};
+  var serializedResource = {};
+  if (model.options.serializer) {
+    return model.options.serializer.call(this, item);
+  }
+  _.forOwn(model.attributes, function (value, key) {
+    if (isReadOnly(key, readOnly)) {
+      return;
+    }
+    if (isRelationship(value)) {
+      serializeRelationship(key, item[key], value, serializedRelationships);
+    } else {
+      serializedAttributes[key] = item[key];
+    }
+  });
+
+  serializedResource.type = typeName;
+  serializedResource.attributes = serializedAttributes;
+
+  if (Object.keys(serializedRelationships).length > 0) {
+    serializedResource.relationships = serializedRelationships;
+  }
+
+  if (item.id) {
+    serializedResource.id = item.id;
+  }
+  return serializedResource;
+}
+
+function isReadOnly(attribute, readOnly) {
+  return readOnly.indexOf(attribute) !== -1;
+}
+
+function isRelationship(attribute) {
+  return _.isPlainObject(attribute) && _.includes(['hasOne', 'hasMany'], attribute.jsonApi);
+}
+
+function serializeRelationship(relationshipName, relationship, relationshipType, serializeRelationships) {
+  if (relationshipType.jsonApi === 'hasMany' && relationship !== undefined) {
+    serializeRelationships[relationshipName] = serializeHasMany(relationship, relationshipType.type);
+  }
+  if (relationshipType.jsonApi === 'hasOne' && relationship !== undefined) {
+    serializeRelationships[relationshipName] = serializeHasOne(relationship, relationshipType.type);
+  }
+}
+
+function serializeHasMany(relationships, type) {
+  return {
+    data: _.map(relationships, function (item) {
+      return { id: item.id, type: type };
+    })
+  };
+}
+
+function serializeHasOne(relationship, type) {
+  if (relationship === null) {
+    return { data: null };
+  }
+  return {
+    data: { id: relationship.id, type: type }
+  };
+}
+
+module.exports = {
+  resource: resource,
+  collection: collection
+};

--- a/lib/middleware/json-api/rails-params-serializer.js
+++ b/lib/middleware/json-api/rails-params-serializer.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var Qs = require('qs');
+
+module.exports = {
+  name: 'rails-params-serializer',
+  req: function req(payload) {
+    if (payload.req.method === 'GET') {
+      payload.req.paramsSerializer = function (params) {
+        return Qs.stringify(params, {
+          arrayFormat: 'brackets',
+          encode: false
+        });
+      };
+    }
+
+    return payload;
+  }
+};

--- a/lib/middleware/json-api/req-delete.js
+++ b/lib/middleware/json-api/req-delete.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  name: 'DELETE',
+  req: function req(payload) {
+    if (payload.req.method === 'DELETE') {
+      payload.req.headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      };
+      delete payload.req.data;
+    }
+
+    return payload;
+  }
+};

--- a/lib/middleware/json-api/req-get.js
+++ b/lib/middleware/json-api/req-get.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  name: 'GET',
+  req: function req(payload) {
+    if (payload.req.method === 'GET') {
+      payload.req.headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      };
+      delete payload.req.data;
+    }
+
+    return payload;
+  }
+};

--- a/lib/middleware/json-api/req-headers.js
+++ b/lib/middleware/json-api/req-headers.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var isEmpty = require('lodash').isEmpty;
+var assign = require('lodash').assign;
+
+module.exports = {
+  name: 'HEADER',
+  req: function req(payload) {
+    if (!isEmpty(payload.jsonApi.headers)) {
+      payload.req.headers = assign({}, payload.req.headers, payload.jsonApi.headers);
+    }
+    return payload;
+  }
+};

--- a/lib/middleware/json-api/req-http-basic-auth.js
+++ b/lib/middleware/json-api/req-http-basic-auth.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var isEmpty = require('lodash').isEmpty;
+
+module.exports = {
+  name: 'HTTP_BASIC_AUTH',
+  req: function req(payload) {
+    if (!isEmpty(payload.jsonApi.auth)) {
+      payload.req.auth = payload.jsonApi.auth;
+    }
+    return payload;
+  }
+};

--- a/lib/middleware/json-api/req-patch.js
+++ b/lib/middleware/json-api/req-patch.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var serialize = require('./_serialize');
+
+module.exports = {
+  name: 'PATCH',
+  req: function req(payload) {
+    var jsonApi = payload.jsonApi;
+
+    if (payload.req.method === 'PATCH') {
+      payload.req.headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      };
+      if (payload.req.data.constructor === Array) {
+        payload.req.data = {
+          data: serialize.collection.call(jsonApi, payload.req.model, payload.req.data)
+        };
+      } else {
+        payload.req.data = {
+          data: serialize.resource.call(jsonApi, payload.req.model, payload.req.data)
+        };
+      }
+    }
+    return payload;
+  }
+};

--- a/lib/middleware/json-api/req-post.js
+++ b/lib/middleware/json-api/req-post.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var serialize = require('./_serialize');
+
+module.exports = {
+  name: 'POST',
+  req: function req(payload) {
+    var jsonApi = payload.jsonApi;
+
+    if (payload.req.method === 'POST') {
+      payload.req.headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      };
+      if (payload.req.data.constructor === Array) {
+        payload.req.data = {
+          data: serialize.collection.call(jsonApi, payload.req.model, payload.req.data)
+        };
+      } else {
+        payload.req.data = {
+          data: serialize.resource.call(jsonApi, payload.req.model, payload.req.data)
+        };
+      }
+    }
+
+    return payload;
+  }
+};

--- a/lib/middleware/json-api/res-deserialize.js
+++ b/lib/middleware/json-api/res-deserialize.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var deserialize = require('./_deserialize');
+var _ = require('lodash');
+
+function needsDeserialization(method) {
+  return ['GET', 'PATCH', 'POST'].indexOf(method) !== -1;
+}
+
+function isCollection(responseData) {
+  return _.isArray(responseData);
+}
+
+module.exports = {
+  name: 'response',
+  res: function res(payload) {
+    /*
+     *   Note: The axios ajax response attaches the actual response data to
+     *         `res.data`. JSON API Resources also passes back the response with
+     *         a `data` attribute. This means we have `res.data.data`.
+     */
+    var jsonApi = payload.jsonApi;
+    var status = payload.res.status;
+    var req = payload.req;
+    var res = payload.res.data;
+    var included = res.included;
+
+    var deserializedResponse = null;
+
+    if (status !== 204 && needsDeserialization(req.method)) {
+      if (isCollection(res.data)) {
+        deserializedResponse = deserialize.collection.call(jsonApi, res.data, included, req.model);
+      } else if (res.data) {
+        deserializedResponse = deserialize.resource.call(jsonApi, res.data, included, req.model);
+      }
+    }
+
+    if (res && deserializedResponse) {
+      var params = ['meta', 'links'];
+      params.forEach(function (param) {
+        deserializedResponse[param] = res[param];
+      });
+    }
+
+    return deserializedResponse;
+  }
+};

--- a/lib/middleware/json-api/res-errors.js
+++ b/lib/middleware/json-api/res-errors.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+function buildErrors(serverErrors) {
+  if (!serverErrors) {
+    console.log('Unidentified error');
+    return;
+  } else {
+    var _ret = function () {
+      var errors = {};
+      serverErrors.errors.forEach(function (error) {
+        errors[errorKey(error.source)] = error.title;
+      });
+      return {
+        v: errors
+      };
+    }();
+
+    if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+  }
+}
+
+function errorKey(source) {
+  return source.pointer.split('/').pop();
+}
+
+module.exports = {
+  name: 'errors',
+  error: function error(payload) {
+    return buildErrors(payload.data);
+  }
+};

--- a/lib/middleware/request.js
+++ b/lib/middleware/request.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  name: 'axios-request',
+  req: function req(payload) {
+    var jsonApi = payload.jsonApi;
+    return jsonApi.axios(payload.req);
+  }
+};


### PR DESCRIPTION
## Priority
High priority. Blocking

## What Changed & Why
Fixes bug described at https://github.com/twg/devour/issues/47.

The main change is that now the function `resource` and `collection` from the module `src/middleware/json-api/_deserialize.js` implement caching to avoid an infinite loop during deserialization of a resource whose relationships were circular, i.e: when a resource A has and belongs to many resource B. Example schema:

~~~js
// phone-number
//   number: str
// 
// user-phone-number-link
//  user-id: foreign_key
//  phone-number-id: foreign-key
//
// user
//   email: str
~~~

... a "user" has many "phone_numbers" and vice-versa.

## Testing
List step-by-step how to test the changes.
- [x] Go to `master` branch and write some circular schema
- [x] Test it and watch if fail like described
- [x] Perform the same test under PR branch and check whether error is fixed. The API of the library should not have changed.
- [ ] Automated tests pending 

## Bug/Ticket Tracker
https://github.com/twg/devour/issues/47.

## In Progress/Follow Up
**Tests pending**