### PR TITLE
Added a check for `buildErrors` function to check for source

### DIFF
--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -1,11 +1,15 @@
+const _ = require('lodash')
+
 function buildErrors (serverErrors) {
   if (!serverErrors) {
     console.log('Unidentified error')
     return
   } else {
     let errors = {}
-    serverErrors.errors.forEach((error) => {
-      errors[errorKey(error.source)] = error.title
+    _.forEach(serverErrors.errors, (error) => {
+      if (error.source) {
+        errors[errorKey(error.source)] = error.title
+      }
     })
     return errors
   }


### PR DESCRIPTION
## Priority

Yes, CIBT-web is seeing this issue
## What Changed & Why

Added a if check on the error source. For example we return 404 for sessions that may not have a source key in the error object

@spiderbites @Emerson @derek-watson 
