### PR TITLE
Simplify individual middleware replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,16 @@ let responseMiddleware = {
   }
 }
 
+let errorMiddleware = {
+  name: 'nothing-to-see-here',
+  error: function (payload) {
+    return { errors: [] }
+  }
+}
+
 jsonApi.insertMiddlewareBefore('axios-request', requestMiddleware)
 jsonApi.insertMiddlewareAfter('response', responseMiddleware)
+jsonApi.replaceMiddleware('errors', errorMiddleware)
 ```
 
 ### Options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "lib/",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -209,6 +209,11 @@ class JsonApi {
     }
   }
 
+  replaceMiddleware (middlewareName, newMiddleware) {
+    let index = _.findIndex(this.middleware, ['name', middlewareName])
+    this.middleware[index] = newMiddleware
+  }
+
   define (modelName, attributes, options = {}) {
     this.models[modelName] = {
       attributes: attributes,


### PR DESCRIPTION
## Priority
High

## What Changed & Why
Devour already provides for the use of a completely custom middleware stack as well as inserting custom middleware, but it doesn't allow outright replacement of a specific piece of middleware. This PR adds `replaceMiddleware`, to do just that.

Readme updated with a simple example.

## Testing
List step-by-step how to test the changes.
- [ ] replace a piece of middleware as outlined in the readme example

## People
@Emerson 
@billxinli 
@themarkappleby 