### PR TITLE
Allow types to be specified directly for relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,34 @@ jsonApi.define('post', {title: ''})
 jsonApi.one('author', 1).all('post').get({include: 'books'}) // GET http://api.yoursite.com/authors/1/posts?include=books
 jsonApi.one('author', 1).all('post').post({title:'title'}, {include: 'books'}) // POST http://api.yoursite.com/authors/1/posts?include=books
 ```
+
+### Polymorphic Relationships
+
+To specify a polymorphic relationship, simply define a model with a polymorphic relationship without specifying its type.
+
+```js
+jsonApi.define('order', {
+  name: '',
+  payables: {
+    jsonApi: 'hasMany'
+  }
+})
+
+let payables = [{id: 4, type: 'subtotal'}, {id: 5, type: 'tax'}]
+let order = jsonApi.all('order').post({ name: 'first', payables })
+/* => POST http://api.yoursite.com/orders
+{
+  type: orders,
+  attributes: {
+    name: 'first'
+  },  
+  relationships: {
+    payables: {
+      data: [
+        { id: 4, type: 'subtotal' },
+        { id: 5, type: 'tax' }
+      ]
+    }
+  }
+} */
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "lib/",
   "scripts": {

--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -62,7 +62,7 @@ function serializeRelationship (relationshipName, relationship, relationshipType
 function serializeHasMany (relationships, type) {
   return {
     data: _.map(relationships, (item) => {
-      return {id: item.id, type: type}
+      return {id: item.id, type: type || item.type}
     })
   }
 }
@@ -72,7 +72,7 @@ function serializeHasOne (relationship, type) {
     return {data: null}
   }
   return {
-    data: {id: relationship.id, type: type}
+    data: {id: relationship.id, type: type || relationship.type}
   }
 }
 

--- a/test/api/serialize-test.js
+++ b/test/api/serialize-test.js
@@ -245,4 +245,36 @@ describe('serialize', () => {
     let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello'})
     expect(serializedItem.custom).to.eql(true)
   })
+
+  it('should serialize polymorphic hasOne relationships', () => {
+    jsonApi.define('order', {
+      title: '',
+      payable: {
+        jsonApi: 'hasOne'
+      }
+    })
+
+    let serializedItem = serialize.resource.call(jsonApi, 'order', {id: '5', title: 'Hello', payable: {id: 4, type: 'subtotal'}})
+    expect(serializedItem.type).to.eql('orders')
+    expect(serializedItem.attributes.title).to.eql('Hello')
+    expect(serializedItem.relationships.payable.data.id).to.eql(4)
+    expect(serializedItem.relationships.payable.data.type).to.eql('subtotal')
+  })
+
+  it('should serialize polymorphic hasMany relationships', () => {
+    jsonApi.define('order', {
+      title: '',
+      payables: {
+        jsonApi: 'hasMany'
+      }
+    })
+
+    let serializedItem = serialize.resource.call(jsonApi, 'order', {id: '5', title: 'Hello', payables: [{id: 4, type: 'subtotal'}, {id: 4, type: 'tax'}]})
+    expect(serializedItem.type).to.eql('orders')
+    expect(serializedItem.attributes.title).to.eql('Hello')
+    expect(serializedItem.relationships.payables.data[0].id).to.eql(4)
+    expect(serializedItem.relationships.payables.data[0].type).to.eql('subtotal')
+    expect(serializedItem.relationships.payables.data[1].id).to.eql(4)
+    expect(serializedItem.relationships.payables.data[1].type).to.eql('tax')
+  })
 })


### PR DESCRIPTION
## What Changed & Why
The motivation for this PR is to allow for serializing polymorphic relationships.

A model with a relationship is defined like:

```
jsonApi.define('order', {
  name: '',
  payables: {
    jsonApi: 'hasMany',
    type: ????
  }
})
```

If `payable` has a polymorphic type, then the type cannot be specified during model definition.

This PR brings in support for serializing types that are not present in model definitions, and can instead be specified directly when a Devour request is being constructed.  See the tests and readme for an example. 

In conjunction with https://github.com/twg/devour/pull/51 this library will have better support in general for polymorphic relationships.

## Testing
- [ ] `npm test`

## Bug/Ticket Tracker
n/a

## Documentation
n/a

## People
@Emerson @billxinli @themarkappleby 