### PR TITLE
Support in the url builder for trailing slashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Devour takes an object as the initializer. The following options are available:
 
 **resetBuilderOnCall**: A boolean to clear the builder stack after a `.get`, `.post`, `.patch`, `.destroy` call. (Default: true)
 
-**auth**: An object with username and password, used to pass in HTTP Basic Authentication Headers, `new JsonApi({apiUrl: 'http://your-api-here.com', auth: {username: 'secret', password: 'cheesecake})`
+**auth**: An object with username and password, used to pass in HTTP Basic Authentication Headers, `new JsonApi({apiUrl: 'http://your-api-here.com', auth: {username: 'secret', password: 'cheesecake'})`
+
+**trailingSlashes**: An optional object to use trailing slashes on resource and/or collection urls (defaults to false), `new JsonApi({apiUrl: 'http://your-api-here.com', trailingSlashes: {resource: false, collection: true})`
 
 ### Relationships
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "lib/",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -46,20 +46,19 @@ class JsonApi {
       throw new Error('Invalid argument, initialize Devour with an object.')
     }
 
-    let defaultSlashes = {collection: false, resource: false}
     let defaults = {
       middleware: jsonApiMiddleware,
       logger: true,
       resetBuilderOnCall: true,
       auth: {},
-      trailingSlash: defaultSlashes
+      trailingSlash: {collection: false, resource: false}
     }
 
-    let deprecatedConstructos = (args) => {
+    let deprecatedConstructors = (args) => {
       return (args.length === 2 || (args.length === 1 && _.isString(args[0])))
     }
 
-    if (deprecatedConstructos(arguments)) {
+    if (deprecatedConstructors(arguments)) {
       defaults.apiUrl = arguments[0]
       if (arguments.length === 2) {
         defaults.middleware = arguments[1]
@@ -68,7 +67,6 @@ class JsonApi {
 
     options = _.defaultsDeep(options, defaults)
     let middleware = options.middleware
-    let slashes = options.trailingSlash
 
     this._originalMiddleware = middleware.slice(0)
     this.middleware = middleware.slice(0)
@@ -82,10 +80,10 @@ class JsonApi {
     this.builderStack = []
     this.resetBuilderOnCall = !!options.resetBuilderOnCall
     this.logger = Minilog('devour')
-    this.trailingSlash = slashes === true ? _.forOwn(_.clone(defaultSlashes), (v, k, o) => { _.set(o, k, true) }) : slashes
+    this.trailingSlash = options.trailingSlash === true ? _.forOwn(_.clone(defaults.trailingSlash), (v, k, o) => { _.set(o, k, true) }) : options.trailingSlash
     options.logger ? Minilog.enable() : Minilog.disable()
 
-    if (deprecatedConstructos(arguments)) {
+    if (deprecatedConstructors(arguments)) {
       this.logger.warn('Constructor (apiUrl, middleware) has been deprecated, initialize Devour with an object.')
     }
   }
@@ -108,13 +106,21 @@ class JsonApi {
     this.builderStack = []
   }
 
+  stackForResource () {
+    return _.hasIn(_.last(this.builderStack), 'id')
+  }
+
+  addSlash () {
+    return this.stackForResource() ? this.trailingSlash.resource : this.trailingSlash.collection
+  }
+
   buildPath () {
     return _.map(this.builderStack, 'path').join('/')
   }
 
-  buildUrl (trailingSlash) {
+  buildUrl () {
     let path = this.buildPath()
-    let slash = trailingSlash === true && path !== '' ? '/' : ''
+    let slash = path !== '' && this.addSlash() ? '/' : ''
     return `${this.apiUrl}/${path}${slash}`
   }
 
@@ -353,8 +359,7 @@ class JsonApi {
     } else if (!_.isUndefined(options.model)) {
       return this.collectionUrlFor(options.model)
     } else {
-      let slash = !_.isUndefined(options.trailingSlash) && options.trailingSlash
-      return this.buildUrl(slash)
+      return this.buildUrl()
     }
   }
 

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -139,7 +139,7 @@ describe('JsonApi', () => {
   })
 
   describe('urlFor, pathFor and path builders', () => {
-    context('default trailing no trailing slashes', () => {
+    context('default no trailing slashes', () => {
       it('should construct collection paths for models', () => {
         jsonApi.define('product', {})
         expect(jsonApi.collectionPathFor('product')).to.eql('products')
@@ -177,11 +177,6 @@ describe('JsonApi', () => {
         expect(jsonApi.all('foo').urlFor()).to.eql('http://myapi.com/foos')
       })
 
-      it('should allow urlFor to be called with the trailingSlash option', () => {
-        expect(jsonApi.urlFor({trailingSlash: true})).to.eql('http://myapi.com/')
-        expect(jsonApi.all('foo').urlFor({trailingSlash: true})).to.eql('http://myapi.com/foos/')
-      })
-
       it('should allow pathFor to be called with various options', () => {
         expect(jsonApi.pathFor({model: 'foo', id: 1})).to.eql('foos/1')
         expect(jsonApi.pathFor({model: 'foo'})).to.eql('foos')
@@ -191,7 +186,7 @@ describe('JsonApi', () => {
       })
     })
 
-    context('with trailing slashes', () => {
+    context('with collection and resource trailing slashes', () => {
       beforeEach(() => {
         jsonApi = new JsonApi({apiUrl: 'http://myapi.com', trailingSlash: {collection: true, resource: true}})
       })
@@ -199,54 +194,63 @@ describe('JsonApi', () => {
       afterEach(() => {
         jsonApi.resetBuilder()
       })
-      it('should construct collection paths for models', () => {
-        jsonApi.define('product', {})
-        expect(jsonApi.collectionPathFor('product')).to.eql('products')
-      })
 
-      it('should allow overrides for collection paths', () => {
-        jsonApi.define('product', {}, {collectionPath: 'my-products'})
-        expect(jsonApi.collectionPathFor('product')).to.eql('my-products')
-      })
-
-      it('should allow arbitrary collections without a model', () => {
-        expect(jsonApi.collectionPathFor('foo')).to.eql('foos')
-      })
-
-      it('should construct single resource paths for models', () => {
-        jsonApi.define('product', {})
-        expect(jsonApi.resourcePathFor('product', 1)).to.eql('products/1')
-      })
-
-      it('should construct collection urls for models', () => {
+      it('should construct collection urls', () => {
         jsonApi.define('product', {})
         expect(jsonApi.collectionUrlFor('product')).to.eql('http://myapi.com/products/')
       })
 
-      it('should construct single resource urls for models', () => {
+      it('should construct resource urls', () => {
         jsonApi.define('product', {})
         expect(jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1/')
       })
 
-      it('should allow urlFor to be called with various options', () => {
-        expect(jsonApi.urlFor({model: 'foo', id: 1})).to.eql('http://myapi.com/foos/1/')
+      it('should construct collection urls with urlFor', () => {
         expect(jsonApi.urlFor({model: 'foo'})).to.eql('http://myapi.com/foos/')
-        expect(jsonApi.urlFor({})).to.eql('http://myapi.com/')
-        expect(jsonApi.urlFor()).to.eql('http://myapi.com/')
+        expect(jsonApi.all('foo').urlFor()).to.eql('http://myapi.com/foos/')
+      })
+
+      it('should construct complex collection urls with urlFor', () => {
+        expect(jsonApi.urlFor({model: 'foo'})).to.eql('http://myapi.com/foos/')
+        expect(jsonApi.one('bar', '1').all('foo').urlFor()).to.eql('http://myapi.com/bars/1/foos/')
+      })
+
+      it('should construct resource urls with urlFor', () => {
+        expect(jsonApi.urlFor({model: 'foo', id: '1'})).to.eql('http://myapi.com/foos/1/')
+        expect(jsonApi.one('foo', '1').urlFor()).to.eql('http://myapi.com/foos/1/')
+      })
+      it('should construct complex resource urls with urlFor', () => {
+        expect(jsonApi.all('bars').one('foo', '1').urlFor()).to.eql('http://myapi.com/bars/foos/1/')
+      })
+    })
+
+    context('with only collection trailing slashes', () => {
+      beforeEach(() => {
+        jsonApi = new JsonApi({apiUrl: 'http://myapi.com', trailingSlash: {collection: true, resource: false}})
+      })
+
+      afterEach(() => {
+        jsonApi.resetBuilder()
+      })
+
+      it('should construct resource urls with urlFor without trailing slashes', () => {
+        expect(jsonApi.urlFor({model: 'foo', id: '1'})).to.eql('http://myapi.com/foos/1')
+        expect(jsonApi.one('foo', '1').urlFor()).to.eql('http://myapi.com/foos/1')
+      })
+    })
+
+    context('with only resource trailing slashes', () => {
+      beforeEach(() => {
+        jsonApi = new JsonApi({apiUrl: 'http://myapi.com', trailingSlash: {collection: false, resource: true}})
+      })
+
+      afterEach(() => {
+        jsonApi.resetBuilder()
+      })
+
+      it('should construct collection urls with urlFor without trailing slashes', () => {
+        expect(jsonApi.urlFor({model: 'foo'})).to.eql('http://myapi.com/foos')
         expect(jsonApi.all('foo').urlFor()).to.eql('http://myapi.com/foos')
-      })
-
-      it('should allow urlFor to be called with the trailingSlash option', () => {
-        expect(jsonApi.urlFor({trailingSlash: true})).to.eql('http://myapi.com/')
-        expect(jsonApi.all('foo').urlFor({trailingSlash: true})).to.eql('http://myapi.com/foos/')
-      })
-
-      it('should allow pathFor to be called with various options', () => {
-        expect(jsonApi.pathFor({model: 'foo', id: 1})).to.eql('foos/1')
-        expect(jsonApi.pathFor({model: 'foo'})).to.eql('foos')
-        expect(jsonApi.pathFor({})).to.eql('')
-        expect(jsonApi.pathFor()).to.eql('')
-        expect(jsonApi.all('foo').pathFor()).to.eql('foos')
       })
     })
   })


### PR DESCRIPTION
## What Changed & Why
Added a constructor option in object form to optionally append trailing slashes to either/both collection and resource urls.

## Bug/Ticket Tracker
Discussed in #57 
