### PR TITLE
Add a config option to disable or change pluralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Devour takes an object as the initializer. The following options are available:
 
 **logger**: A boolean to enable or disable the logger. (Default: true)
 
+**pluralize**: A function like [pluralize](https://www.npmjs.com/package/pluralize), or `false` to disable pluralization. (Default: `require('pluralize')`)
+
 **resetBuilderOnCall**: A boolean to clear the builder stack after a `.get`, `.post`, `.patch`, `.destroy` call. (Default: true)
 
 **auth**: An object with username and password, used to pass in HTTP Basic Authentication Headers, `new JsonApi({apiUrl: 'http://your-api-here.com', auth: {username: 'secret', password: 'cheesecake'})`

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,14 @@ class JsonApi {
     this.builderStack = []
     this.resetBuilderOnCall = !!options.resetBuilderOnCall
     this.logger = Minilog('devour')
+    if (options.pluralize === false) {
+      this.pluralize = s => s
+      this.pluralize.singular = s => s
+    } else if ('pluralize' in options) {
+      this.pluralize = options.pluralize
+    } else {
+      this.pluralize = pluralize
+    }
     this.trailingSlash = options.trailingSlash === true ? _.forOwn(_.clone(defaults.trailingSlash), (v, k, o) => { _.set(o, k, true) }) : options.trailingSlash
     options.logger ? Minilog.enable() : Minilog.disable()
 
@@ -332,7 +340,7 @@ class JsonApi {
   }
 
   collectionPathFor (modelName) {
-    let collectionPath = _.get(this.models[modelName], 'options.collectionPath') || pluralize(modelName)
+    let collectionPath = _.get(this.models[modelName], 'options.collectionPath') || this.pluralize(modelName)
     return `${collectionPath}`
   }
 

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -1,5 +1,4 @@
 const _ = require('lodash')
-const pluralize = require('pluralize')
 
 function collection (items, included, responseModel) {
   return items.map(item => {
@@ -8,7 +7,7 @@ function collection (items, included, responseModel) {
 }
 
 function resource (item, included, responseModel) {
-  let model = this.modelFor(pluralize.singular(item.type))
+  let model = this.modelFor(this.pluralize.singular(item.type))
   if (!model) {
     throw new Error('The JSON API response had a type of "' + item.type + '" but Devour expected the type to be "' + responseModel + '".')
   }

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -1,15 +1,15 @@
 const _ = require('lodash')
 
-function collection (items, included, responseModel) {
+function collection (items, included) {
   return items.map(item => {
-    return resource.call(this, item, included, responseModel)
+    return resource.call(this, item, included)
   })
 }
 
-function resource (item, included, responseModel) {
+function resource (item, included) {
   let model = this.modelFor(this.pluralize.singular(item.type))
   if (!model) {
-    throw new Error('The JSON API response had a type of "' + item.type + '" but Devour expected the type to be "' + responseModel + '".')
+    throw new Error('Could not find definition for model "' + this.pluralize.singular(item.type) + '" which was returned by the JSON API.')
   }
 
   if (model.options.deserializer) {

--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -1,5 +1,4 @@
 const _ = require('lodash')
-const pluralize = require('pluralize')
 
 function collection (modelName, items) {
   return items.map(item => {
@@ -11,7 +10,7 @@ function resource (modelName, item) {
   let model = this.modelFor(modelName)
   let options = model.options || {}
   let readOnly = options.readOnly || []
-  let typeName = options.type || pluralize(modelName)
+  let typeName = options.type || this.pluralize(modelName)
   let serializedAttributes = {}
   let serializedRelationships = {}
   let serializedResource = {}

--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -27,9 +27,9 @@ module.exports = {
 
     if (status !== 204 && needsDeserialization(req.method)) {
       if (isCollection(res.data)) {
-        deserializedResponse = deserialize.collection.call(jsonApi, res.data, included, req.model)
+        deserializedResponse = deserialize.collection.call(jsonApi, res.data, included)
       } else if (res.data) {
-        deserializedResponse = deserialize.resource.call(jsonApi, res.data, included, req.model)
+        deserializedResponse = deserialize.resource.call(jsonApi, res.data, included)
       }
     }
 

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -101,6 +101,33 @@ describe('JsonApi', () => {
       jsonApi.one('foo', 1).get().then(() => done())
     })
 
+    describe('Pluralize options', () => {
+      context('no options passed -- default behavior', () => {
+        it('should use the pluralize package', () => {
+          jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
+          expect(jsonApi.pluralize).to.eql(require('pluralize'))
+        })
+      })
+
+      context('false -- no pluralization', () => {
+        it('should not pluralize text', () => {
+          jsonApi = new JsonApi({apiUrl: 'http://myapi.com', pluralize: false})
+          expect(jsonApi.pluralize('model')).to.eql('model')
+          expect(jsonApi.pluralize.singular('models')).to.eql('models')
+        })
+      })
+
+      context('custom pluralization', () => {
+        it('should pluralize as requested', () => {
+          const pluralizer = s => 'Q' + s
+          pluralizer.singular = s => s.replace(/^Q/, '')
+          jsonApi = new JsonApi({apiUrl: 'http://myapi.com', pluralize: pluralizer})
+          expect(jsonApi.pluralize('model')).to.eql('Qmodel')
+          expect(jsonApi.pluralize.singular('Qmodel')).to.eql('model')
+        })
+      })
+    })
+
     describe('Trailing Slash options', () => {
       context('no options passed -- default behavior', () => {
         it('should use the default of no slashes for either url type', () => {


### PR DESCRIPTION
I have an API which does not pluralize the names of its models. This PR adds an option to disable pluralization so I can use Devour as my client, and also custom pluralization for other users who might have different pluralization requirements not covered by the default `pluralize`.

Incidental to this change is an update to an error message. The original problem was that the error message did not reflect the expected pluralization, leading to the confusing error `The JSON API response had a type of "Products" but Devour expected the type to be "Products"`. While I was at it I also changed the message to reflect the actual underlying problem, modifying the code originally added by #10 as the response model was no longer needed for the error message.
