### PR TITLE
add params to create and update requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ jsonApi.create('post', {
   title: 'hello',
   content: 'some content',
   tags: ['one', 'two']
+}, {
+  include: 'tags'
 })
 
 // To update...
@@ -55,6 +57,8 @@ jsonApi.update('post', {
   title: 'new title',
   content: 'new content',
   tags: ['new tag']
+}, {
+  include: 'tags'
 })
 
 // To destroy...

--- a/src/index.js
+++ b/src/index.js
@@ -326,12 +326,13 @@ class JsonApi {
     return this.runMiddleware(req)
   }
 
-  update (modelName, payload) {
+  update (modelName, payload, params = {}) {
     let req = {
       method: 'PATCH',
       url: this.urlFor({model: modelName, id: payload.id}),
       model: modelName,
-      data: payload
+      data: payload,
+      params: params
     }
     return this.runMiddleware(req)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -315,11 +315,12 @@ class JsonApi {
     return this.runMiddleware(req)
   }
 
-  create (modelName, payload) {
+  create (modelName, payload, params = {}) {
     let req = {
       method: 'POST',
       url: this.urlFor({model: modelName}),
       model: modelName,
+      params: params,
       data: payload
     }
     return this.runMiddleware(req)

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -410,6 +410,28 @@ describe('JsonApi', () => {
         .then(() => done()).catch(() => done())
     })
 
+    it('should make basic update call', (done) => {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload) => {
+          expect(payload.req.method).to.be.eql('PATCH')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos')
+          expect(payload.req.data).to.be.eql({title: 'foo'})
+          expect(payload.req.params).to.be.eql({include: 'something'})
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      jsonApi.define('foo', {
+        title: ''
+      })
+
+      jsonApi.update('foo', {title: 'foo'}, {include: 'something'})
+        .then(() => done()).catch(() => done())
+    })
+
     it('should include meta information on response objects', (done) => {
       mockResponse(jsonApi, {
         data: {

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -395,6 +395,7 @@ describe('JsonApi', () => {
           expect(payload.req.method).to.be.eql('POST')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos')
           expect(payload.req.data).to.be.eql({title: 'foo'})
+          expect(payload.req.params).to.be.eql({include: 'something'})
           return {}
         }
       }
@@ -405,7 +406,8 @@ describe('JsonApi', () => {
         title: ''
       })
 
-      jsonApi.create('foo', {title: 'foo'}).then(() => done()).catch(() => done())
+      jsonApi.create('foo', {title: 'foo'}, {include: 'something'})
+        .then(() => done()).catch(() => done())
     })
 
     it('should include meta information on response objects', (done) => {


### PR DESCRIPTION
## Priority
Yes, we needed to implement this to call some endpoints and reduce numbers of calling

## What Changed & Why
- Added params in the signature of create and update methods.
- Make create or update requests with include params to get back related resources.