### PR TITLE
Hotfix/many to many

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -15,6 +15,10 @@ const cache = new class {
     const match = _.find(this._cache, r => r.type === type && r.id === id)
     return match && match.deserialized
   }
+
+  clear () {
+    this._cache = []
+  }
 }
 
 function collection (items, included, useCache = false) {
@@ -70,7 +74,7 @@ function resource (item, included, useCache = false) {
     }
   })
 
-  cache.set(item.type, item.id, deserializedModel)
+  cache.clear()
 
   return deserializedModel
 }

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -704,8 +704,8 @@ describe('JsonApi', () => {
         // console.log('request 1', clans);
         // console.log('memberships', clans[0].memberships);
         expect(clans[0].memberships.length).to.eql(2)
-        // expect(clans[0].memberships[0].clan.id).to.eql("42")
-        // expect(clans[0].memberships[1].clan.id).to.eql("42")
+        expect(clans[0].memberships[0].clan.id).to.eql('42')
+        expect(clans[0].memberships[1].clan.id).to.eql('42')
         // second request
         mockResponse(jsonApi, {
           data: {
@@ -780,9 +780,9 @@ describe('JsonApi', () => {
         jsonApi.find('clan', 42, { include: 'memberships,memberships.player' }).then((clan) => {
           // console.log('request 2: ', clan);
           expect(clan.memberships[0].player.name).to.eql('Dragonfire')
-          // expect(clan.memberships[0].clan.id).to.eql('42')
+          expect(clan.memberships[0].clan.id).to.eql('42')
           expect(clan.memberships[1].player.name).to.eql('nicooga')
-          // expect(clan.memberships[1].clan.id).to.eql('42')
+          expect(clan.memberships[1].clan.id).to.eql('42')
           done()
         }).catch(err => console.log(err))
       }).catch(err => console.log(err))

--- a/test/helpers/mock-response.js
+++ b/test/helpers/mock-response.js
@@ -1,5 +1,5 @@
 export default function (jsonApi, res = {}) {
-  jsonApi.middleware.unshift({
+  let mockResponse = {
     name: 'mock-response',
     req: (payload) => {
       payload.req.adapter = function (resolve) {
@@ -7,5 +7,11 @@ export default function (jsonApi, res = {}) {
       }
       return payload
     }
-  })
+  }
+  // if we already mocked something replace it
+  if (jsonApi.middleware[0].name === mockResponse.name) {
+    jsonApi.middleware[0] = mockResponse
+  } else {
+    jsonApi.middleware.unshift(mockResponse)
+  }
 }


### PR DESCRIPTION
For #82 and #84

## Priority
Currently I must reload my page to avoid outdated data ...
If this PR got merged and the new devour client is released I can publish the next version of my webapp^^

## Screenshot

![image](https://cloud.githubusercontent.com/assets/1217999/26103183/904eb51a-3a38-11e7-9927-224a51450c54.png)
1. This is the correct result after the first request, because the `player` of the second `membership` is not included, but if the a second request include the second `player` object fromt he secodn `membership` it is ignored, because the `membership` is fetched from the cache ...
2. `attachHasOneFor` assume that the entity is in the include block, it is possible that the entity the or inside the `data` block.

## What Changed & Why
Clear cache after each request to avoid outdated data .
Cache is also used to resolve has `HasOne` relations.

## Testing
Implementest tests

## Bug/Ticket Tracker
#82 
#84 
