### PR TITLE
Hotfx/cache

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -15,6 +15,10 @@ const cache = new class {
     const match = _.find(this._cache, r => r.type === type && r.id === id)
     return match && match.deserialized
   }
+
+  clear () {
+    this._cache = []
+  }
 }
 
 function collection (items, included, useCache = false) {
@@ -70,7 +74,7 @@ function resource (item, included, useCache = false) {
     }
   })
 
-  cache.set(item.type, item.id, deserializedModel)
+  cache.clear()
 
   return deserializedModel
 }

--- a/test/helpers/mock-response.js
+++ b/test/helpers/mock-response.js
@@ -1,5 +1,5 @@
 export default function (jsonApi, res = {}) {
-  jsonApi.middleware.unshift({
+  let mockResponse = {
     name: 'mock-response',
     req: (payload) => {
       payload.req.adapter = function (resolve) {
@@ -7,5 +7,11 @@ export default function (jsonApi, res = {}) {
       }
       return payload
     }
-  })
+  }
+  // if we already mocked something replace it
+  if (jsonApi.middleware[0].name === mockResponse.name) {
+    jsonApi.middleware[0] = mockResponse
+  } else {
+    jsonApi.middleware.unshift(mockResponse)
+  }
 }


### PR DESCRIPTION
Replace https://github.com/twg/devour/pull/83

## Priority
Blocking, we get outdated data and cannot use the last version

## Bug/Ticket Tracker
#82 

## What Changed & Why
Reset cache to return new data instead of outdated from cache

## Screenshot

![image](https://cloud.githubusercontent.com/assets/1217999/26103183/904eb51a-3a38-11e7-9927-224a51450c54.png)
1. This is the correct result after the first request, because the `player` of the second `membership` is not included, but if the a second request include the second `player` object fromt the second `membership` it is ignored, because the `membership` is fetched from the cache ...