### PR TITLE
checks if lowerCamel key exists upon missing attr

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -42,7 +42,12 @@ function resource (item, included, useCache = false) {
   let deserializedModel = {id: item.id, type: item.type}
 
   _.forOwn(item.attributes, (value, attr) => {
-    const attrConfig = model.attributes[attr]
+    var attrConfig = model.attributes[attr]
+
+    if (_.isUndefined(attrConfig) && attr !== 'id') {
+      attr = attr.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase() })
+      attrConfig = model.attributes[attr]
+    }
 
     if (_.isUndefined(attrConfig) && attr !== 'id') {
       console.warn(`Resource response contains attribute "${attr}", but it is not present on model config and therefore not deserialized.`)
@@ -55,7 +60,12 @@ function resource (item, included, useCache = false) {
   cache.set(item.type, item.id, deserializedModel)
 
   _.forOwn(item.relationships, (value, rel) => {
-    const relConfig = model.attributes[rel]
+    var relConfig = model.attributes[rel]
+
+    if (_.isUndefined(relConfig)) {
+      rel = rel.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase() })
+      relConfig = model.attributes[rel]
+    }
 
     if (_.isUndefined(relConfig)) {
       console.warn(`Resource response contains relationship "${rel}", but it is not present on model config and therefore not deserialized.`)


### PR DESCRIPTION
## Priority
Is this PR blocking your next action?

Yes.

## What Changed & Why
JSON API spec dictates that keys use dashes, but javascript convention is lowerCamel

The examples all use one word keys so the problem of consuming a two-word key never comes up.

This change checks if a lowerCamel attribute exists on the config model if the first does not.

I could have put the replace line before the initial attrConfig assignment but this avoids doing a replace unless the key is missing the first time around.

