### PR TITLE
buildErrors; pass the correct variable as data is not defined

### DIFF
--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -18,6 +18,6 @@ function errorKey (source) {
 module.exports = {
   name: 'errors',
   error: function (payload) {
-    return buildErrors(payload.data)
+    return buildErrors(payload.response.data)
   }
 }


### PR DESCRIPTION
## Priority
High 

## What Changed & Why
The wrong value was passed to the buildError functions. Therefore the real errors where never returned. 

