### PR TITLE
#94 Fixed - Support URL encoding of parameter values

### DIFF
--- a/src/middleware/json-api/rails-params-serializer.js
+++ b/src/middleware/json-api/rails-params-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
       payload.req.paramsSerializer = function (params) {
         return Qs.stringify(params, {
           arrayFormat: 'brackets',
-          encode: false
+          encodeValuesOnly: true
         })
       }
     }


### PR DESCRIPTION
This looks like the correct encoding now - keys and brackets get left as-is, but any values get encoded.

Keys with spaces in will still be unsupported, but the cause of this bug (and probably the much more common case) of having spaces in the values is fixed by this change.
