### PR TITLE
Remove console statements and use logger everywhere

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 const Promise = require('es6-promise').Promise
 const deserialize = require('./middleware/json-api/_deserialize')
 const serialize = require('./middleware/json-api/_serialize')
-const Minilog = require('minilog')
+const Logger = require('./logger')
 
 /*
  *   == JsonApiMiddleware
@@ -79,7 +79,6 @@ class JsonApi {
     this.serialize = serialize
     this.builderStack = []
     this.resetBuilderOnCall = !!options.resetBuilderOnCall
-    this.logger = Minilog('devour')
     if (options.pluralize === false) {
       this.pluralize = s => s
       this.pluralize.singular = s => s
@@ -89,15 +88,15 @@ class JsonApi {
       this.pluralize = pluralize
     }
     this.trailingSlash = options.trailingSlash === true ? _.forOwn(_.clone(defaults.trailingSlash), (v, k, o) => { _.set(o, k, true) }) : options.trailingSlash
-    options.logger ? Minilog.enable() : Minilog.disable()
+    options.logger ? Logger.enable() : Logger.disable()
 
     if (deprecatedConstructors(arguments)) {
-      this.logger.warn('Constructor (apiUrl, middleware) has been deprecated, initialize Devour with an object.')
+      Logger.warn('Constructor (apiUrl, middleware) has been deprecated, initialize Devour with an object.')
     }
   }
 
   enableLogging (enabled = true) {
-    enabled ? Minilog.enable() : Minilog.disable()
+    enabled ? Logger.enable() : Logger.disable()
   }
 
   one (model, id) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,37 @@
+const Minilog = require('minilog')
+
+class Logger {
+  static debug (message) {
+    this.instantiate().debug(message)
+  }
+
+  static disable () {
+    Minilog.disable()
+  }
+
+  static enable () {
+    Minilog.enable()
+  }
+
+  static error (message) {
+    this.instantiate().error(message)
+  }
+
+  static info (message) {
+    this.instantiate().info(message)
+  }
+
+  static instantiate () {
+    if (!this.minilog) {
+      this.minilog = Minilog('devour')
+    }
+
+    return this.minilog
+  }
+
+  static warn (message) {
+    this.instantiate().warn(message)
+  }
+}
+
+module.exports = Logger

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const Logger = require('../../logger')
 
 const cache = new class {
   constructor () { this._cache = [] }
@@ -50,7 +51,7 @@ function resource (item, included, useCache = false) {
     }
 
     if (_.isUndefined(attrConfig) && attr !== 'id') {
-      console.warn(`Resource response contains attribute "${attr}", but it is not present on model config and therefore not deserialized.`)
+      Logger.warn(`Resource response contains attribute "${attr}", but it is not present on model config and therefore not deserialized.`)
     } else {
       deserializedModel[attr] = value
     }
@@ -68,9 +69,9 @@ function resource (item, included, useCache = false) {
     }
 
     if (_.isUndefined(relConfig)) {
-      console.warn(`Resource response contains relationship "${rel}", but it is not present on model config and therefore not deserialized.`)
+      Logger.warn(`Resource response contains relationship "${rel}", but it is not present on model config and therefore not deserialized.`)
     } else if (!isRelationship(relConfig)) {
-      console.warn(`Resource response contains relationship "${rel}", but it is present on model config as a plain attribute.`)
+      Logger.warn(`Resource response contains relationship "${rel}", but it is present on model config as a plain attribute.`)
     } else {
       deserializedModel[rel] =
         attachRelationsFor.call(this, model, relConfig, item, included, rel)

--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -1,6 +1,8 @@
+const Logger = require('../../logger')
+
 function buildErrors (serverErrors) {
   if (!serverErrors) {
-    console.log('Unidentified error')
+    Logger.error('Unidentified error')
     return
   } else {
     let errors = {}


### PR DESCRIPTION
## Priority
Priority: high.

It would make testing and debugging much faster and easier.

## What Changed & Why

All the console statements have been removed in favor of the main logger. The logger has been converted to a singleton that can be imported in all files.

Why? Because then logs can be turned off.

## Testing
List step-by-step how to test the changes.
- [ ] Create a resource that has missing definitions.
- [ ] Turn off logging.
- [ ] You should see no warnings.

## Bug/Ticket Tracker
See #93.

## Documentation
No documentation changes necessary.