### PR TITLE
Add 'relationships()' to URL builder for accessing relationships on API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,11 @@ class JsonApi {
     return this
   }
 
+  relationships () {
+    this.builderStack.push({path: 'relationships'})
+    return this
+  }
+
   resetBuilder () {
     this.builderStack = []
   }

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -242,6 +242,10 @@ describe('JsonApi', () => {
         expect(jsonApi.one('bar', '1').all('foo').urlFor()).to.eql('http://myapi.com/bars/1/foos/')
       })
 
+      it('should construct the relationships URL', () => {
+        expect(jsonApi.one('bar', '1').relationships().all('foo').urlFor()).to.eql('http://myapi.com/bars/1/relationships/foos/')
+      })
+
       it('should construct resource urls with urlFor', () => {
         expect(jsonApi.urlFor({model: 'foo', id: '1'})).to.eql('http://myapi.com/foos/1/')
         expect(jsonApi.one('foo', '1').urlFor()).to.eql('http://myapi.com/foos/1/')
@@ -739,7 +743,7 @@ describe('JsonApi', () => {
       }).catch(err => console.log(err))
     })
 
-    it('should not cache the second requeset', (done) => {
+    it('should not cache the second request', (done) => {
       mockResponse(jsonApi, {
         data: {
           data: [{


### PR DESCRIPTION
## Priority
Priority: low
The absence of this feature can by bypassed by chaining " ->all('relationship')" in the URL builder.

## What Changed & Why
Adds convenient "relationships()" method for URL builder.

## Testing
List step-by-step how to test the changes.
- [ ] Build an API relationship URL
- [ ] ???
- [ ] Profit

## Bug/Ticket Tracker
https://github.com/twg/devour/issues/46

## Documentation
Example:
```js
const create = this.availableDevices.map((device) => {
    return {type: 'devices', id: device.id}
});
JsonApi.one('project', this.project.id).relationships().all('device').post(create)
```

API documentation:
http://jsonapi.org/format/#fetching-relationships
http://jsonapi.org/format/#crud-updating-relationships
