### PR TITLE
Model exception handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "lib/",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -344,12 +344,12 @@ class JsonApi {
   modelFor (modelName) {
     if (modelName) {
       if (!this.models[modelName]) {
-        throw new Error('API resource definition for model \'' + modelName + '\' not found.')
+        throw new Error('API resource definition for model \'${modelName}\' not found.')
       }
       return this.models[modelName] || {}
-    } else {
-      return {}
     }
+
+    return {}
   }
 
   collectionPathFor (modelName) {

--- a/src/index.js
+++ b/src/index.js
@@ -344,7 +344,7 @@ class JsonApi {
   modelFor (modelName) {
     if (modelName) {
       if (!this.models[modelName]) {
-        throw new Error('API resource definition for model ' + modelName + ' not found.')
+        throw new Error('API resource definition for model \'' + modelName + '\' not found.')
       }
       return this.models[modelName] || {}
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -342,7 +342,14 @@ class JsonApi {
   }
 
   modelFor (modelName) {
-    return this.models[modelName]
+    if (modelName) {
+      if (!this.models[modelName]) {
+        throw new Error('API resource definition for model ' + modelName + ' not found.')
+      }
+      return this.models[modelName] || {}
+    } else {
+      return {}
+    }
   }
 
   collectionPathFor (modelName) {

--- a/src/index.js
+++ b/src/index.js
@@ -342,14 +342,11 @@ class JsonApi {
   }
 
   modelFor (modelName) {
-    if (modelName) {
-      if (!this.models[modelName]) {
-        throw new Error('API resource definition for model \'${modelName}\' not found.')
-      }
-      return this.models[modelName] || {}
+    if (!this.models[modelName]) {
+      throw new Error('API resource definition for model "${modelName}" not found.')
     }
 
-    return {}
+    return this.models[modelName]
   }
 
   collectionPathFor (modelName) {

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -34,9 +34,6 @@ function resource (item, included, useCache = false) {
   }
 
   let model = this.modelFor(this.pluralize.singular(item.type))
-  if (!model) {
-    throw new Error('Could not find definition for model "' + this.pluralize.singular(item.type) + '" which was returned by the JSON API.')
-  }
   if (model.options.deserializer) return model.options.deserializer.call(this, item)
 
   let deserializedModel = {id: item.id, type: item.type}

--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -14,8 +14,8 @@ function resource (modelName, item) {
   let serializedAttributes = {}
   let serializedRelationships = {}
   let serializedResource = {}
-  if (model.options.serializer) {
-    return model.options.serializer.call(this, item)
+  if (options.serializer) {
+    return options.serializer.call(this, item)
   }
   _.forOwn(model.attributes, (value, key) => {
     if (isReadOnly(key, readOnly)) {

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -654,6 +654,10 @@ describe('JsonApi', () => {
 
       jsonApi.destroy('foo', 1).then(() => done()).catch(() => done())
     })
+
+    it.skip('should throw an error while attempting to access undefined model', (done) => {
+      expect(jsonApi.findAll('derp').then(() => done()).catch(() => done())).toThrow(/API/)
+    })
   })
 
   describe('Complex API calls', () => {

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -655,8 +655,8 @@ describe('JsonApi', () => {
       jsonApi.destroy('foo', 1).then(() => done()).catch(() => done())
     })
 
-    it.skip('should throw an error while attempting to access undefined model', (done) => {
-      expect(jsonApi.findAll('derp').then(() => done()).catch(() => done())).toThrow(/API/)
+    it.skip('should throw an error while attempting to access undefined model', function (done) {
+      expect(function () { jsonApi.findAll('derp').then(done).catch(done) }).to.throwException(/API resource definition for model/)
     })
   })
 


### PR DESCRIPTION
## Priority
Priority: low
PR as proposed is just a convenience feature for developers and does not affect a production environment.

## What Changed & Why
With the current version (v2.0.3) if the query builder is used to reference a model which is not defined, eventually code execution just fails with no feedback other than an attempt to access an 'options' property on an undefined object. This is a simple change to communicate which model lookup failed.

## Testing
List step-by-step how to test the changes.
- [ ] Attempt to construct an API URL/query using a model type which is not defined
- [ ] Check console and see an Error message.

## In Progress/Follow Up
I included an example unit test however it is currently disabled. IT DOES NOT WORK. Basically I am not familiar with this unit tester and I am not sure how to include an "expect an error to be thrown" test. Please review and adjust, thanks.