### PR TITLE
Support relationship destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A lightweight, framework agnostic, flexible JSON API client",
   "main": "lib/",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -186,30 +186,31 @@ class JsonApi {
   }
 
   destroy () {
+    let req = null
+
     if (arguments.length === 2) {
-      let req = {
+      req = {
         method: 'DELETE',
         url: this.urlFor({model: arguments[0], id: arguments[1]}),
         model: arguments[0],
         data: {}
       }
-      return this.runMiddleware(req)
     } else {
-      let lastRequest = _.chain(this.builderStack).last()
+      const lastRequest = _.chain(this.builderStack).last()
 
-      let req = {
+      req = {
         method: 'DELETE',
         url: this.urlFor(),
         model: lastRequest.get('model').value(),
-        data: {}
+        data: arguments.length === 1 ? arguments[0] : {}
       }
 
       if (this.resetBuilderOnCall) {
         this.resetBuilder()
       }
-
-      return this.runMiddleware(req)
     }
+
+    return this.runMiddleware(req)
   }
 
   insertMiddlewareBefore (middlewareName, newMiddleware) {

--- a/src/middleware/json-api/req-delete.js
+++ b/src/middleware/json-api/req-delete.js
@@ -6,7 +6,11 @@ module.exports = {
         'Content-Type': 'application/vnd.api+json',
         'Accept': 'application/vnd.api+json'
       }
-      delete payload.req.data
+
+      const data = payload.req.data
+      if (typeof data === 'object' && Object.keys(data).length === 0) {
+        delete payload.req.data
+      }
     }
 
     return payload

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -666,7 +666,7 @@ describe('JsonApi', () => {
         }
       }
 
-      jsonApi.middleware = [inspectorMiddleware]
+      jsonApi.middleware = [jsonApiDeleteMiddleware, inspectorMiddleware]
 
       const payload = [
         {type: 'bar', id: 2},

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -654,6 +654,27 @@ describe('JsonApi', () => {
 
       jsonApi.destroy('foo', 1).then(() => done()).catch(() => done())
     })
+
+    it('should accept a data payload on DELETE requests when provided as a single argument', (done) => {
+      let inspectorMiddleware = {
+        name: 'inspector-middleware',
+        req: (payload) => {
+          expect(payload.req.method).to.be.eql('DELETE')
+          expect(payload.req.data).to.be.an('array')
+          expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/relationships/bars')
+          return {}
+        }
+      }
+
+      jsonApi.middleware = [inspectorMiddleware]
+
+      const payload = [
+        {type: 'bar', id: 2},
+        {type: 'bar', id: 3}
+      ]
+
+      jsonApi.one('foo', 1).all('relationship').all('bar').destroy(payload).then(() => done()).catch(() => done())
+    })
   })
 
   describe('Complex API calls', () => {

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -677,7 +677,7 @@ describe('JsonApi', () => {
         {type: 'bar', id: 3}
       ]
 
-      jsonApi.one('foo', 1).all('relationship').all('bar').destroy(payload).then(() => done()).catch(() => done())
+      jsonApi.one('foo', 1).relationships().all('bar').destroy(payload).then(() => done()).catch(() => done())
     })
   })
 


### PR DESCRIPTION
## Priority
Priority: high

This package fails to comply with the JSON API spec by not allowing relationship records to be deleted at present.

## What Changed & Why
The destroy() method accepts either zero or two arguments. When destroying has-many relationship records, a list of relationship record objects ('type' and 'id') are required. This PR allows for this case.

## Testing
List step-by-step how to test the changes.
- [ ] Use destroy() in its current form as normal with two arguments to make sure it still works and compatibility is not broken
- [ ] Call destroy() on a has-one relationship to try to remove it
- [ ] Call destroy() with an array of relationship record objects on a has-many relationship

## Bug/Ticket Tracker
Related Issue: https://github.com/twg/devour/issues/55
Another PR I submitted which is closely related to this: https://github.com/twg/devour/pull/99

## Documentation
http://jsonapi.org/format/#crud-updating-relationships

## In Progress/Follow Up
A unit test is included, which relies on a hacky work-around of the absence of a "relationships()" chain method for the URL builder, a feature which my other PR linked above addresses. If the other PR is accepted, the unit test should be revised to not use the hacky trick.

This line:
```js
jsonApi.one('foo', 1).all('relationship').all('bar').destroy(payload).then(() => done()).catch(() => done())
```

Should be changed to this:
```js
jsonApi.one('foo', 1).relationships().all('bar').destroy(payload).then(() => done()).catch(() => done())
```
