### PR TITLE
Fix destroy data handling

### DIFF
--- a/src/middleware/json-api/req-delete.js
+++ b/src/middleware/json-api/req-delete.js
@@ -8,8 +8,12 @@ module.exports = {
       }
 
       const data = payload.req.data
-      if (typeof data === 'object' && Object.keys(data).length === 0) {
-        delete payload.req.data
+      if (typeof data === 'object') {
+        if (Object.keys(data).length === 0) {
+          delete payload.req.data
+        } else {
+          payload.req.data = { data }
+        }
       }
     }
 

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -664,7 +664,8 @@ describe('JsonApi', () => {
         name: 'inspector-middleware',
         req: (payload) => {
           expect(payload.req.method).to.be.eql('DELETE')
-          expect(payload.req.data).to.be.an('array')
+          expect(payload.req.data).to.be.an('object')
+          expect(payload.req.data.data).to.be.an('array')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/relationships/bars')
           return {}
         }


### PR DESCRIPTION
## Priority
Priority: high

Corrects an error in the data package sent with the API request

## What Changed & Why
My PR which added data payload handling to the "destroy()" method does not correctly follow the pattern of the "post()" and "patch()" methods, because it did not take the method input and enclose it within a "data" object as the spec requires. As a result, if used the way intended, the API request would be rejected with a "400 BAD REQUEST" response.

The unit test for this action was also not testing this correctly, hence it got through.

This has been tested in my own project and works as expected.

Example
```js
const payload = [
{type: 'bars', id: '2'},
{type: 'bars', id: '3'}
]
jsonApi.one('foo', 1)->relationships()->all('bar')->destroy(payload)
```

API request to 'http://myapi.com/foos/1/relationships/bars' of type "DELETE"

Previous request payload (incorrect):
```js
[{"type":"bars","id":"2"},{"type":"bars","id":"3"}]
```

New payload (correct):
```js
{"data":[{"type":"bars","id":"2"},{"type":"bars","id":"3"}]}
```

## Documentation
http://jsonapi.org/format/#crud-updating-relationships
