### PR TITLE
Fix Logger error call on API error response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -287,7 +287,7 @@ class JsonApi {
         return this.applyResponseMiddleware(responsePromise)
       })
       .catch((err) => {
-        this.logger.error(err)
+        Logger.error(err)
         let errorPromise = Promise.resolve(err)
         return this.applyErrorMiddleware(errorPromise).then(err => {
           return Promise.reject(err)


### PR DESCRIPTION
## Priority
Priority: very high
Yes, this is a fatal error on any API error response including naturally expected responses like 422 on data validation.

## What Changed & Why
This one Logger error message call was missed in the recent conversion to using Logger, which also dropped binding the logger to "this.logger". The current code throws an "undefined" error.

## Testing
Cause any API error response, either with a bad data package or failing a validation test.
