### PR TITLE
if pointer isn't defined use index as key

### DIFF
--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -6,15 +6,19 @@ function buildErrors (serverErrors) {
     return
   } else {
     let errors = {}
-    serverErrors.errors.forEach((error) => {
-      errors[errorKey(error.source)] = error.title
-    })
+    for (let [index, error] of serverErrors.errors.entries()) {
+      errors[errorKey(index, error.source)] = { title: error.title, detail: error.detail }
+    }
     return errors
   }
 }
 
-function errorKey (source) {
-  return source.pointer.split('/').pop()
+function errorKey (index, source) {
+  if (source.pointer == null) {
+    return index
+  } else {
+    return source.pointer.split('/').pop()
+  }
 }
 
 module.exports = {

--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -16,9 +16,8 @@ function buildErrors (serverErrors) {
 function errorKey (index, source) {
   if (source.pointer == null) {
     return index
-  } else {
-    return source.pointer.split('/').pop()
   }
+  return source.pointer.split('/').pop()
 }
 
 module.exports = {


### PR DESCRIPTION
## Priority
medium 

## What Changed & Why
The error handling only supported errors with a pointer. JSON API specs also define errors that have no pointers.  See: http://jsonapi.org/examples/#error-objects-multiple-errors. There are document errors as well as parameter errors. The last one still needs to be added though. 

Also only the title of the error was returned. In our case we also wanted the detail of the error.  That's why I created a object which contains the title and the detail. 

## Testing
I only tested in our frontend and this works. I did not write new tests. 

## In Progress/Follow Up
It would be nice if we also parse parameter errors correctly. 


