### PR TITLE
Add a check for source object when indexing error

### DIFF
--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -14,7 +14,7 @@ function buildErrors (serverErrors) {
 }
 
 function errorKey (index, source) {
-  if (source.pointer == null) {
+  if (!source || source.pointer == null) {
     return index
   }
   return source.pointer.split('/').pop()


### PR DESCRIPTION
## Priority

Is this PR blocking your next action? Kinda

## What Changed & Why

Before calling source.pointer, check source is defined, when indexing errors.

## Bug/Ticket Tracker

Small change for issue #111.

## Documentation

http://jsonapi.org/format/#error-objects

## In Progress/Follow Up

The spec seems to suggest an error could have other values that maybe we could be returned also?

* id: a unique identifier for this particular occurrence of the problem.
* links: a links object containing the following members:
* about: a link that leads to further details about this particular occurrence of the problem.
* status: the HTTP status code applicable to this problem, expressed as a string value.
* code: an application-specific error code, expressed as a string value.
* title: a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization.
* detail: a human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.
* source: an object containing references to the source of the error, optionally including any of the following members:
 ** pointer: a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].
 ** parameter: a string indicating which URI query parameter caused the error.
* meta: a meta object containing non-standard meta-information about the error.
