### PR TITLE
Handle errors which don't include a source at all

### DIFF
--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -14,7 +14,7 @@ function buildErrors (serverErrors) {
 }
 
 function errorKey (index, source) {
-  if (source.pointer == null) {
+  if (!source || source.pointer == null) {
     return index
   }
   return source.pointer.split('/').pop()


### PR DESCRIPTION
## Priority
Is this PR blocking your next action?
No, but we have hacky middlewares in all of our applications which could be easily fixed by this small change.

## Screenshot
![image](https://user-images.githubusercontent.com/6242344/34486883-cc89359a-efc9-11e7-807b-d2f921fab6a8.png)


## What Changed & Why
A previous commit (8b2f301c2ac8a52b469369ef7148805ee48113d3) to handle when error sources don't have pointers, but it seems from various PR's/issues (#72, #111, #53) that this could still be an issue (and is in our organisation) when the error has no source at all.

This ensures the library doesn't explode when the error has no source at all, causing it fail gracefully in the same way it does if there is no pointer.

## Testing
Use devour with a response of errors which don't contain a source. E.g.:

```
HTTP/1.1 404 Not Found
content-type: application/vnd.api+json
connection: close
content-length: 79

{"errors":[{"title":"API::ResourceNotFound","detail":"API::ResourceNotFound"}]}
```

## Bug/Ticket Tracker
#72, #111, #53

## Documentation
-

## In Progress/Follow Up
-

## Legal/Security/Privacy
-

## Third-Party
-

## People
Mention people who would be interested in the changeset:
Engineer(s) who wrote the old version
Designer(s)
Product manager (if they’re interested)
