### PR TITLE
Fix relationship loading for models with dashes

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -58,20 +58,25 @@ function resource (item, included, useCache = false) {
   cache.set(item.type, item.id, deserializedModel)
 
   _.forOwn(item.relationships, (value, rel) => {
+    // We need to save the unadulterated relationship key so that we can look relatedItemsFor can
+    // find the right items.
+    let key = rel
     var relConfig = model.attributes[rel]
 
+    // If we fail to look up the relationship config by its model name attempt to find
+    // the attribute to populate by camelcasing the name.
     if (_.isUndefined(relConfig)) {
       rel = rel.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase() })
       relConfig = model.attributes[rel]
     }
 
     if (_.isUndefined(relConfig)) {
-      Logger.warn(`Resource response contains relationship "${rel}", but it is not present on model config and therefore not deserialized.`)
+      Logger.warn(`Resource response contains relationship "${key}", but it is not present on model config and therefore not deserialized.`)
     } else if (!isRelationship(relConfig)) {
-      Logger.warn(`Resource response contains relationship "${rel}", but it is present on model config as a plain attribute.`)
+      Logger.warn(`Resource response contains relationship "${key}", but it is present on model config as a plain attribute.`)
     } else {
       deserializedModel[rel] =
-        attachRelationsFor.call(this, model, relConfig, item, included, rel)
+        attachRelationsFor.call(this, model, relConfig, item, included, key)
     }
   })
 

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -77,12 +77,59 @@ describe('deserialize', () => {
     expect(product.type).to.eql('products')
     expect(product.title).to.eql('hello')
     expect(product.tags).to.be.an('array')
+    expect(product.complexTags.length).to.eql(2)
     expect(product.tags[0].id).to.eql('5')
     expect(product.tags[0].type).to.eql('tags')
     expect(product.tags[0].name).to.eql('one')
     expect(product.tags[1].id).to.eql('6')
     expect(product.tags[1].type).to.eql('tags')
     expect(product.tags[1].name).to.eql('two')
+  })
+
+  it('should deserialize relationships with dashes', () => {
+    jsonApi.define('product', {
+      title: '',
+      complexTags: {
+        jsonApi: 'hasMany',
+        type: 'complex-tags'
+      }
+    })
+    jsonApi.define('complex-tag', {
+      name: ''
+    })
+    let mockResponse = {
+      data: {
+        id: '1',
+        type: 'products',
+        attributes: {
+          title: 'hello'
+        },
+        relationships: {
+          'complex-tags': {
+            data: [
+              {id: '5', type: 'complex-tags'},
+              {id: '6', type: 'complex-tags'}
+            ]
+          }
+        }
+      },
+      included: [
+        {id: '5', type: 'complex-tags', attributes: {name: 'one'}},
+        {id: '6', type: 'complex-tags', attributes: {name: 'two'}}
+      ]
+    }
+    let product = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
+    expect(product.id).to.eql('1')
+    expect(product.type).to.eql('products')
+    expect(product.title).to.eql('hello')
+    expect(product.complexTags).to.be.an('array')
+    expect(product.complexTags.length).to.eql(2)
+    expect(product.complexTags[0].id).to.eql('5')
+    expect(product.complexTags[0].type).to.eql('complex-tags')
+    expect(product.complexTags[0].name).to.eql('one')
+    expect(product.complexTags[1].id).to.eql('6')
+    expect(product.complexTags[1].type).to.eql('complex-tags')
+    expect(product.complexTags[1].name).to.eql('two')
   })
 
   it('should deserialize collections of resource items', () => {


### PR DESCRIPTION
Previously when we encountered a relationship with a model that included
a dash in the name we would mangle to the relationship name in the
process of trying to find the relationship config. This caused us to
fail to find the actual data for the relationship deeper down in the
stack when we call `relatedItemsFor`.

This change ensures that the original relationship name is kept
unmangled so that we can use it later to look up the data.

As a side note the current logic to try and find the relationship
configuration is a little brittle with regard to the way that it
actually finds the fields that the included data maps to. We could
probably go further here and just scan all of the fields to see if any
of them are relationship configs and then populate whatever we find
(where data has been included).

## Priority
I plan to have npm pull from my fork for now, but I'm effectively blocked from using the client on my existing JSON API without integrating this change.

## Screenshot
N/A

## What Changed & Why
Previously when we encountered a relationship with a model that included
a dash in the name we would mangle to the relationship name in the
process of trying to find the relationship config. This caused us to
fail to find the actual data for the relationship deeper down in the
stack when we call `relatedItemsFor`.

This change ensures that the original relationship name is kept
unmangled so that we can use it later to look up the data.

## Testing
I've added a test for the case for the one to many relationship that should fully cover the gap. I'm happy to add an additional test for one-to-many if desired.

## Bug/Ticket Tracker
I didn't find anything in the bug tracker that indicated that this was a known issue.

## Documentation
I didn't find anything relevant.

## In Progress/Follow Up
As a side note the current logic to try and find the relationship
configuration is a little brittle with regard to the way that it
actually finds the fields that the included data maps to. We could
probably go further here and just scan all of the fields to see if any
of them are relationship configs and then populate whatever we find
(where data has been included).

## Legal/Security/Privacy
None.

## Third-Party
None.

## People
It looks like Jascha Sundaresan <jascha.sundaresan@oracle.com> and Dragonfire <bastian616-git@yahoo.de> are the most recent developers to touch this area of the code.