### PR TITLE
Polyfill global Promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const axios = require('axios')
 const pluralize = require('pluralize')
 const _ = require('lodash')
-const Promise = require('es6-promise').Promise
+require('es6-promise').polyfill()
 const deserialize = require('./middleware/json-api/_deserialize')
 const serialize = require('./middleware/json-api/_serialize')
 const Logger = require('./logger')


### PR DESCRIPTION
## Priority
Blocks integration with Angular (and potentially other code manipulating the global Promise object). Patching the library source code on the consumer side is a possible workaround, but far from ideal.

## What Changed & Why
Previously, devour would always use the es6-promise implementation, even if a global Promise object was available. Preferring the native implementation makes sense already, but in combination with Zone.js, it is necessary not to break functionality. Zone.js augments the global Promise implementation so it correctly interacts with zones - and since devour gets its own Promise implementation, it breaks. The various zone-related interceptors are not called when the promises returned by devour complete, and since Angular triggers its change detection mechanism with these interceptors, that also doesn't work.

## Testing
- [ ] Include devour-client in an Angular application / after Zone.js is loaded
- [ ] Verify that devour gets the same ZoneAwarePromise constructor that's available as the global "Promise" value.