### PR TITLE
Add meta and links for resource objects in serialization

### DIFF
--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -45,6 +45,14 @@ function resource (modelName, item) {
   if (item.id) {
     serializedResource.id = item.id
   }
+
+  if (item.meta) {
+    serializedResource.meta = item.meta
+  }
+
+  if (item.links) {
+    serializedResource.links = item.links
+  }
   return serializedResource
 }
 

--- a/test/api/serialize-test.js
+++ b/test/api/serialize-test.js
@@ -243,6 +243,20 @@ describe('serialize', () => {
     expect(serializedItem.id).to.eql('5')
   })
 
+  it('should serialize meta on resource if present', () => {
+    jsonApi.define('product', {title: ''})
+    let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello', meta: {customStuff: 'More custom stuff'}})
+    expect(serializedItem.type).to.eql('products')
+    expect(serializedItem.meta.customStuff).to.eql('More custom stuff')
+  })
+
+  it('should serialize links on resource if present', () => {
+    jsonApi.define('product', {title: ''})
+    let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello', links: {self: 'http://example.com/products'}})
+    expect(serializedItem.type).to.eql('products')
+    expect(serializedItem.links.self).to.eql('http://example.com/products')
+  })
+
   it('should allow for custom serialization if present on the model', () => {
     jsonApi.define('product', {title: ''}, {
       serializer: () => {


### PR DESCRIPTION
## Priority
Unable to use this library given the fact that we need to use meta and links of resources. 

## Screenshot
N/A

## What Changed & Why
Currently serialization of resource object only checks for 'type' and 'id' top-level members and everything else is included in 'attributes'. Although these two members are required, specification allows also for 'meta' and 'links' top-level members. With this change, item 'meta' and 'links' fields will be serialized separately as specified in [specification](http://jsonapi.org/format/#document-resource-objects)

## Testing
Tests have been added to test/api/serialize-test.js to cover for default serialization of meta and links members on resources.

## Bug/Ticket Tracker
Related to [this issue](https://github.com/twg/devour/issues/26), but from serialization perspective.

## Documentation
[JSONAPI Resource Spec](http://jsonapi.org/format/#document-resource-objects) defining meta and links members on resource.
