### PR TITLE
Require only lodash specifics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,20 @@
 const axios = require('axios')
 const pluralize = require('pluralize')
-const _ = require('lodash')
+// Import only what we use from lodash.
+const _isUndefined = require('lodash/isUndefined')
+const _isString = require('lodash/isString')
+const _isPlainObject = require('lodash/isPlainObject')
+const _isArray = require('lodash/isArray')
+const _defaultsDeep = require('lodash/defaultsDeep')
+const _forOwn = require('lodash/forOwn')
+const _clone = require('lodash/clone')
+const _get = require('lodash/get')
+const _set = require('lodash/set')
+const _hasIn = require('lodash/hasIn')
+const _last = require('lodash/last')
+const _map = require('lodash/map')
+const _findIndex = require('lodash/findIndex')
+
 require('es6-promise').polyfill()
 const deserialize = require('./middleware/json-api/_deserialize')
 const serialize = require('./middleware/json-api/_serialize')
@@ -42,7 +56,7 @@ let jsonApiMiddleware = [
 class JsonApi {
 
   constructor (options = {}) {
-    if (!(arguments.length === 2 && _.isString(arguments[0]) && _.isArray(arguments[1])) && !(arguments.length === 1 && (_.isPlainObject(arguments[0]) || _.isString(arguments[0])))) {
+    if (!(arguments.length === 2 && _isString(arguments[0]) && _isArray(arguments[1])) && !(arguments.length === 1 && (_isPlainObject(arguments[0]) || _isString(arguments[0])))) {
       throw new Error('Invalid argument, initialize Devour with an object.')
     }
 
@@ -55,7 +69,7 @@ class JsonApi {
     }
 
     let deprecatedConstructors = (args) => {
-      return (args.length === 2 || (args.length === 1 && _.isString(args[0])))
+      return (args.length === 2 || (args.length === 1 && _isString(args[0])))
     }
 
     if (deprecatedConstructors(arguments)) {
@@ -65,7 +79,7 @@ class JsonApi {
       }
     }
 
-    options = _.defaultsDeep(options, defaults)
+    options = _defaultsDeep(options, defaults)
     let middleware = options.middleware
 
     this._originalMiddleware = middleware.slice(0)
@@ -87,7 +101,7 @@ class JsonApi {
     } else {
       this.pluralize = pluralize
     }
-    this.trailingSlash = options.trailingSlash === true ? _.forOwn(_.clone(defaults.trailingSlash), (v, k, o) => { _.set(o, k, true) }) : options.trailingSlash
+    this.trailingSlash = options.trailingSlash === true ? _forOwn(_clone(defaults.trailingSlash), (v, k, o) => { _set(o, k, true) }) : options.trailingSlash
     options.logger ? Logger.enable() : Logger.disable()
 
     if (deprecatedConstructors(arguments)) {
@@ -119,7 +133,7 @@ class JsonApi {
   }
 
   stackForResource () {
-    return _.hasIn(_.last(this.builderStack), 'id')
+    return _hasIn(_last(this.builderStack), 'id')
   }
 
   addSlash () {
@@ -127,7 +141,7 @@ class JsonApi {
   }
 
   buildPath () {
-    return _.map(this.builderStack, 'path').join('/')
+    return _map(this.builderStack, 'path').join('/')
   }
 
   buildUrl () {
@@ -152,12 +166,12 @@ class JsonApi {
   }
 
   post (payload, params = {}, meta = {}) {
-    let lastRequest = _.chain(this.builderStack).last()
+    let lastRequest = _last(this.builderStack)
 
     let req = {
       method: 'POST',
       url: this.urlFor(),
-      model: lastRequest.get('model').value(),
+      model: _get(lastRequest, 'model'),
       data: payload,
       params,
       meta
@@ -171,12 +185,12 @@ class JsonApi {
   }
 
   patch (payload, params = {}, meta = {}) {
-    let lastRequest = _.chain(this.builderStack).last()
+    let lastRequest = _last(this.builderStack)
 
     let req = {
       method: 'PATCH',
       url: this.urlFor(),
-      model: lastRequest.get('model').value(),
+      model: _get(lastRequest, 'model'),
       data: payload,
       params,
       meta
@@ -200,12 +214,12 @@ class JsonApi {
         data: {}
       }
     } else {
-      const lastRequest = _.chain(this.builderStack).last()
+      const lastRequest = _last(this.builderStack)
 
       req = {
         method: 'DELETE',
         url: this.urlFor(),
-        model: lastRequest.get('model').value(),
+        model: _get(lastRequest, 'model'),
         data: arguments.length === 1 ? arguments[0] : {}
       }
 
@@ -237,7 +251,7 @@ class JsonApi {
   }
 
   replaceMiddleware (middlewareName, newMiddleware) {
-    let index = _.findIndex(this.middleware, ['name', middlewareName])
+    let index = _findIndex(this.middleware, ['name', middlewareName])
     this.middleware[index] = newMiddleware
   }
 
@@ -355,7 +369,7 @@ class JsonApi {
   }
 
   collectionPathFor (modelName) {
-    let collectionPath = _.get(this.models[modelName], 'options.collectionPath') || this.pluralize(modelName)
+    let collectionPath = _get(this.models[modelName], 'options.collectionPath') || this.pluralize(modelName)
     return `${collectionPath}`
   }
 
@@ -377,9 +391,9 @@ class JsonApi {
   }
 
   urlFor (options = {}) {
-    if (!_.isUndefined(options.model) && !_.isUndefined(options.id)) {
+    if (!_isUndefined(options.model) && !_isUndefined(options.id)) {
       return this.resourceUrlFor(options.model, options.id)
-    } else if (!_.isUndefined(options.model)) {
+    } else if (!_isUndefined(options.model)) {
       return this.collectionUrlFor(options.model)
     } else {
       return this.buildUrl()
@@ -387,9 +401,9 @@ class JsonApi {
   }
 
   pathFor (options = {}) {
-    if (!_.isUndefined(options.model) && !_.isUndefined(options.id)) {
+    if (!_isUndefined(options.model) && !_isUndefined(options.id)) {
       return this.resourcePathFor(options.model, options.id)
-    } else if (!_.isUndefined(options.model)) {
+    } else if (!_isUndefined(options.model)) {
       return this.collectionPathFor(options.model)
     } else {
       return this.buildPath()

--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -1,4 +1,7 @@
-const _ = require('lodash')
+const _isPlainObject = require('lodash/isPlainObject')
+const _includes = require('lodash/includes')
+const _map = require('lodash/map')
+const _forOwn = require('lodash/forOwn')
 
 function collection (modelName, items) {
   return items.map(item => {
@@ -17,7 +20,7 @@ function resource (modelName, item) {
   if (options.serializer) {
     return options.serializer.call(this, item)
   }
-  _.forOwn(model.attributes, (value, key) => {
+  _forOwn(model.attributes, (value, key) => {
     if (isReadOnly(key, readOnly)) {
       return
     }
@@ -53,7 +56,7 @@ function isReadOnly (attribute, readOnly) {
 }
 
 function isRelationship (attribute) {
-  return (_.isPlainObject(attribute) && _.includes(['hasOne', 'hasMany'], attribute.jsonApi))
+  return (_isPlainObject(attribute) && _includes(['hasOne', 'hasMany'], attribute.jsonApi))
 }
 
 function serializeRelationship (relationshipName, relationship, relationshipType, serializeRelationships) {
@@ -67,7 +70,7 @@ function serializeRelationship (relationshipName, relationship, relationshipType
 
 function serializeHasMany (relationships, type) {
   return {
-    data: _.map(relationships, (item) => {
+    data: _map(relationships, (item) => {
       return {id: item.id, type: type || item.type}
     })
   }

--- a/src/middleware/json-api/req-headers.js
+++ b/src/middleware/json-api/req-headers.js
@@ -1,11 +1,11 @@
-const isEmpty = require('lodash').isEmpty
-const assign = require('lodash').assign
+const _isEmpty = require('lodash/isEmpty')
+const _assign = require('lodash/assign')
 
 module.exports = {
   name: 'HEADER',
   req: (payload) => {
-    if (!isEmpty(payload.jsonApi.headers)) {
-      payload.req.headers = assign({}, payload.req.headers, payload.jsonApi.headers)
+    if (!_isEmpty(payload.jsonApi.headers)) {
+      payload.req.headers = _assign({}, payload.req.headers, payload.jsonApi.headers)
     }
     return payload
   }

--- a/src/middleware/json-api/req-http-basic-auth.js
+++ b/src/middleware/json-api/req-http-basic-auth.js
@@ -1,9 +1,9 @@
-const isEmpty = require('lodash').isEmpty
+const _isEmpty = require('lodash/isEmpty')
 
 module.exports = {
   name: 'HTTP_BASIC_AUTH',
   req: (payload) => {
-    if (!isEmpty(payload.jsonApi.auth)) {
+    if (!_isEmpty(payload.jsonApi.auth)) {
       payload.req.auth = payload.jsonApi.auth
     }
     return payload

--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -1,12 +1,12 @@
 const deserialize = require('./_deserialize')
-const _ = require('lodash')
+const _isArray = require('lodash/isArray')
 
 function needsDeserialization (method) {
   return ['GET', 'PATCH', 'POST'].indexOf(method) !== -1
 }
 
 function isCollection (responseData) {
-  return _.isArray(responseData)
+  return _isArray(responseData)
 }
 
 module.exports = {


### PR DESCRIPTION
## Priority
PR is not blocking. However, the way devour currently requires lodash makes it impossible to optimise bundles. For example using webpack. Since devour always requires the full library. Devour is the only dependency we have that does this, and the only reason for a couple of hundred unused Kbs in our bundle.js.
 
## Screenshot
Okay....
![screen shot 2018-06-19 at 09 23 36](https://user-images.githubusercontent.com/129898/41582803-e1ed3f96-73a2-11e8-8522-e2d5c6565731.png)

## What Changed & Why
This PR rewrites the requires to only pick the parts of lodash that are used. Use of lodash `chain` method was removed, and split into a separate call to `last()` and `get`. This makes it easy to optimise bundles that Devour is built into along with lodash.

## Testing
`npm run test`

