### PR TITLE
Support responses with text response data

### DIFF
--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -30,6 +30,9 @@ module.exports = {
   error: function (payload) {
     if (payload.response) {
       if (payload.response.data) {
+        if (typeof payload.response.data === 'string') {
+          return buildErrors({error: `${payload.response.statusText}: ${payload.response.data}`})
+        }
         return buildErrors(payload.response.data)
       }
       return buildErrors({error: payload.response.statusText})


### PR DESCRIPTION
Relevant for responses such as 401 Unauthorized: 'Invalid email or token'
