### PR TITLE
Keep ids of related resources that are not included in the response

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -48,7 +48,7 @@ function resource (item, included, useCache = false) {
   let model = this.modelFor(this.pluralize.singular(item.type))
   if (model.options.deserializer) return model.options.deserializer.call(this, item)
 
-  let deserializedModel = {id: item.id, type: item.type}
+  let deserializedModel = { id: item.id, type: item.type }
 
   _forOwn(item.attributes, (value, attr) => {
     var attrConfig = model.attributes[attr]
@@ -117,9 +117,13 @@ function attachHasOneFor (model, attribute, item, included, key) {
   let relatedItems = relatedItemsFor(model, attribute, item, included, key)
   if (relatedItems && relatedItems[0]) {
     return resource.call(this, relatedItems[0], included, true)
-  } else {
-    return null
   }
+
+  const relatedId = _get(item.relationships, [key, 'data', 'id'], false)
+  if (relatedId) {
+    return relatedId
+  }
+  return null
 }
 
 function attachHasManyFor (model, attribute, item, included, key) {
@@ -130,6 +134,12 @@ function attachHasManyFor (model, attribute, item, included, key) {
   if (relatedItems && relatedItems.length > 0) {
     return collection.call(this, relatedItems, included, true)
   }
+
+  const relatedIds = _get(item.relationships, [key, 'data'], false)
+  if (relatedIds) {
+    return _map(relatedIds, relatedItem => relatedItem.id)
+  }
+
   return []
 }
 

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -225,15 +225,15 @@ describe('deserialize', () => {
         relationships: {
           tags: {
             data: [
-            {id: '5', type: 'tags'},
-            {id: '6', type: 'tags'}
+              { id: '5', type: 'tags' },
+              { id: '6', type: 'tags' }
             ]
           }
         }
       },
       included: [
-      {id: '5', type: 'tags'},
-      {id: '6', type: 'tags', attributes: {name: 'two'}}
+        { id: '5', type: 'tags' },
+        { id: '6', type: 'tags', attributes: { name: 'two' } }
       ]
     }
     let product = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
@@ -244,5 +244,41 @@ describe('deserialize', () => {
     expect(product.tags[0].name).to.be.undefined
     expect(product.tags[1].id).to.eql('6')
     expect(product.tags[1].name).to.eql('two')
+  })
+
+  it('should deserialize ids of related resources that are not included', () => {
+    jsonApi.define('product', {
+      title: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tags'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+    let mockResponse = {
+      data: {
+        id: '1',
+        type: 'products',
+        attributes: {
+          title: 'hello'
+        },
+        relationships: {
+          tags: {
+            data: [
+              { id: '5', type: 'tags' },
+              { id: '6', type: 'tags' }
+            ]
+          }
+        }
+      }
+    }
+    let product = deserialize.resource.call(jsonApi, mockResponse.data)
+    expect(product.id).to.eql('1')
+    expect(product.title).to.eql('hello')
+    expect(product.tags).to.be.an('array')
+    expect(product.tags[0]).to.eql('5')
+    expect(product.tags[1]).to.eql('6')
   })
 })


### PR DESCRIPTION
## Priority
Is this PR blocking your next action? - Kind of. We're using a patched version of devour for the moment.

## What Changed & Why
It's valid JSON API to specify the ids of relationships without including the related resources under the 'included' key. Currently devour throws that information away. This PR keeps the ids of the related resources in the information returned by devour.

## Testing
List step-by-step how to test the changes.
- [x] A test is included
