### PR TITLE
Add logic around cache to prevent complex relationship infinite loop

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -46,7 +46,7 @@ function resource (item, included, useCache = false) {
   }
 
   let model = this.modelFor(this.pluralize.singular(item.type))
-  if (model.options.deserializer) return model.options.deserializer.call(this, item)
+  if (model.options.deserializer) return model.options.deserializer.call(this, item, included)
 
   let deserializedModel = {id: item.id, type: item.type}
 

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -93,8 +93,6 @@ function resource (item, included, useCache = false) {
     }
   })
 
-  cache.clear()
-
   return deserializedModel
 }
 
@@ -173,6 +171,7 @@ function isRelatedItemFor (attribute, relatedItem, relationMapItem) {
 }
 
 module.exports = {
+  cache: cache,
   resource: resource,
   collection: collection
 }

--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -34,6 +34,7 @@ module.exports = {
       } else if (res.data) {
         data = deserialize.resource.call(jsonApi, res.data, included)
       }
+      deserialize.cache.clear()
     }
 
     if (res.data && data) {

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -85,6 +85,131 @@ describe('deserialize', () => {
     expect(product.tags[1].name).to.eql('two')
   })
 
+  it('should deserialize complex relations without going into an infinite loop', () => {
+    jsonApi.define('course', {
+      title: '',
+      instructor: {
+        jsonApi: 'hasOne',
+        type: 'instructors'
+      },
+      lessons: {
+        jsonApi: 'hasMany',
+        type: 'lessons'
+      }
+    })
+    jsonApi.define('lesson', {
+      title: '',
+      course: {
+        jsonApi: 'hasOne',
+        type: 'courses'
+      },
+      instructor: {
+        jsonApi: 'hasOne',
+        type: 'instructors'
+      }
+    })
+    jsonApi.define('instructor', {
+      name: '',
+      lessons: {
+        jsonApi: 'hasMany',
+        type: 'lessons'
+      }
+    })
+
+    let mockResponse = {
+      data: {
+        id: '1',
+        type: 'courses',
+        attributes: {
+          title: 'hello'
+        },
+        relationships: {
+          lessons: {
+            data: [
+              {
+                id: '42',
+                type: 'lessons'
+              },
+              {
+                id: '43',
+                type: 'lessons'
+              }
+            ]
+          },
+          instructor: {
+            data: {
+              id: '5',
+              type: 'instructors'
+            }
+          }
+        }
+      },
+      included: [
+        { id: '42', type: 'lessons', attributes: {title: 'sp-one'},
+          relationships: {
+            course: {
+              data: {
+                id: '1',
+                type: 'courses'
+              }
+            },
+            instructor: {
+              data: {
+                id: '5',
+                type: 'instructors'
+              }
+            }
+          }
+        },
+        {id: '43', type: 'lessons', attributes: {title: 'sp-two'},
+          relationships: {
+            course: {
+              data: {
+                id: '1',
+                type: 'courses'
+              }
+            },
+            instructor: {
+              data: {
+                id: '5',
+                type: 'instructors'
+              }
+            }
+          }
+        },
+        {id: '5', type: 'instructors', attributes: {name: 'instructor one'},
+          relationships: {
+            lessons: {
+              data: [
+                {
+                  id: '42',
+                  type: 'lessons'
+                },
+                {
+                  id: '43',
+                  type: 'lessons'
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+    let course = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
+    expect(course.id).to.eql('1')
+    expect(course.instructor.type).to.eql('instructors')
+    expect(course.instructor.lessons).to.be.an('array')
+    expect(course.instructor.lessons.length).to.equal(2)
+    expect(course.lessons).to.be.an('array')
+    expect(course.lessons.length).to.equal(2)
+    expect(course.lessons[0].type).to.eql('lessons')
+    expect(course.lessons[0].id).to.eql('42')
+    expect(course.lessons[0].instructor.id).to.eql('5')
+    expect(course.lessons[1].type).to.eql('lessons')
+    expect(course.lessons[1].id).to.eql('43')
+    expect(course.lessons[1].instructor.id).to.eql('5')
+  })
+
   it('should deserialize collections of resource items', () => {
     jsonApi.define('product', {
       title: '',


### PR DESCRIPTION
## Priority

This is a blocker for us because we have some fairly complex associations that often reference one another. For the most part it works out fine but we have two instances where an infinite loop occurs.

## What Changed & Why
I changed the logic around `cache.clear()` so we can keep the object cache around until we are done deserializing the root object.

## Testing
If you want to see the bug in action you can simply revert the change in src and run the test that I added.

Assuming you've pulled down my branch:
```
git checkout HEAD~1 -- src/middleware/json-api/_deserialize.js
./node_modules/.bin/mocha -g 'should deserialize complex relations without going into an infinite loop'
# When done
git checkout HEAD src/middleware/json-api/_deserialize.js
```
