### PR TITLE
Modify relationships not named after their type

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,22 @@ jsonApi.one('author', 1).all('post').get({include: 'books'}) // GET http://api.y
 jsonApi.one('author', 1).all('post').post({title:'title'}, {include: 'books'}) // POST http://api.yoursite.com/authors/1/posts?include=books
 ```
 
+JSON API Specs also allow the _relationships_ between resources to be created, updated and deleted. For example, `/authors/1/relationships/posts` defines the relationships between an author and its post. You can use `.patch`, `.post` and `.delete` to edit relationships ([read more](http://jsonapi.org/format/#crud-updating-relationships)).
+
+For example:
+
+```js
+let jsonApi = new JsonApi({apiUrl: 'http://api.yoursite.com'})
+jsonApi.define('author', {name: '', articles: { jsonApi: 'hasMany', type: 'post' } })
+jsonApi.define('post', {title: ''})
+
+jsonApi.create('author', { name: 'Joanna Blogs' }) // Create an author
+jsonApi.create('post', { title: 'How to Make Relationships' }) // Create a post
+
+// Create a relationship between the author and the post
+jsonApi.one('author', 1).relationships('articles').patch([{ type: 'post', id: 1 }]) 
+```
+
 ### Polymorphic Relationships
 
 To specify a polymorphic relationship, simply define a model with a polymorphic relationship without specifying its type.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ jsonApi.create('author', { name: 'Joanna Blogs' }) // Create an author
 jsonApi.create('post', { title: 'How to Make Relationships' }) // Create a post
 
 // Create a relationship between the author and the post
-jsonApi.one('author', 1).relationships('articles').patch([{ type: 'post', id: 1 }]) 
+jsonApi.one('author', 1).relationships('articles').patch([{ id: 1 }]) 
 ```
 
 ### Polymorphic Relationships

--- a/src/index.js
+++ b/src/index.js
@@ -123,20 +123,19 @@ class JsonApi {
     return this
   }
 
-  relationships (relationship) {
+  relationships (relationshipName) {
     let lastRequest = _last(this.builderStack)
     this.builderStack.push({ path: 'relationships' })
-    if (!relationship) return this
+    if (!relationshipName) return this
 
     let modelName = _get(lastRequest, 'model')
-    let model = this.modelFor(modelName)
-    let relationshipAttribute = model.attributes[relationship]
-
-    if (!relationshipAttribute) {
-      throw new Error(`API resource definition on model "${modelName}" for relationship "${relationship}" not found. Available attributes: ${Object.keys(model.attributes)}`)
+    if (!modelName) {
+      throw new Error('Relationships must be called with a preceeding model.')
     }
 
-    this.builderStack.push({ path: relationship, model: relationshipAttribute.type })
+    let relationship = this.relationshipFor(modelName, relationshipName)
+
+    this.builderStack.push({ path: relationshipName, model: relationship.type })
 
     return this
   }
@@ -381,6 +380,17 @@ class JsonApi {
     }
 
     return this.models[modelName]
+  }
+
+  relationshipFor (modelName, relationshipName) {
+    let model = this.modelFor(modelName)
+    let relationship = model.attributes[relationshipName]
+
+    if (!relationship) {
+      throw new Error(`API resource definition on model "${modelName}" for relationship "${relationshipName}" not found. Available attributes: ${Object.keys(model.attributes)}`)
+    }
+
+    return relationship
   }
 
   collectionPathFor (modelName) {

--- a/src/index.js
+++ b/src/index.js
@@ -126,12 +126,12 @@ class JsonApi {
   relationships (relationship) {
     let lastRequest = _last(this.builderStack)
     this.builderStack.push({ path: 'relationships' })
-    if (!relationship) return this 
-    
+    if (!relationship) return this
+
     let modelName = _get(lastRequest, 'model')
     let model = this.modelFor(modelName)
     let relationshipAttribute = model.attributes[relationship]
-    
+
     if (!relationshipAttribute) {
       throw new Error(`API resource definition on model "${modelName}" for relationship "${relationship}" not found. Available attributes: ${Object.keys(model.attributes)}`)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -123,8 +123,21 @@ class JsonApi {
     return this
   }
 
-  relationships () {
-    this.builderStack.push({path: 'relationships'})
+  relationships (relationship) {
+    let lastRequest = _last(this.builderStack)
+    this.builderStack.push({ path: 'relationships' })
+    if (!relationship) return this 
+    
+    let modelName = _get(lastRequest, 'model')
+    let model = this.modelFor(modelName)
+    let relationshipAttribute = model.attributes[relationship]
+    
+    if (!relationshipAttribute) {
+      throw new Error(`API resource definition on model "${modelName}" for relationship "${relationship}" not found. Available attributes: ${Object.keys(model.attributes)}`)
+    }
+
+    this.builderStack.push({ path: relationship, model: relationshipAttribute.type })
+
     return this
   }
 

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -293,6 +293,12 @@ describe('JsonApi', () => {
             .then(() => done())
             .catch(() => done())
         })
+
+        it('complains if the relationship is not defined', () => {
+          expect(function () { 
+            jsonApi.one('order', 1).relationships('baz').patch({}).then(done).catch(done) 
+          }).to.throwException(/API resource definition on model "order" for relationship "baz"/)
+        })
       })
 
       it('should construct resource urls with urlFor', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,10 +581,6 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
-
 babylon@^6.17.2, babylon@^6.17.4:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"


### PR DESCRIPTION
## Priority
Is this PR blocking your next action?
Yes, we cannot update relationships which are not named the same as their type

## Screenshot
![image](https://user-images.githubusercontent.com/6242344/46768179-2c6e4e80-ccdf-11e8-9626-c3c4196399e9.png)


## What Changed & Why
Pretend we some models defined as such:

```js
jsonApi.define('tourist', {
  name: '',
  favourite_cities: {
    jsonApi: 'hasMany',
    type: 'city'
  },
  visited_cities: {
    jsonApi: 'hasMany',
    type: 'city'
  }
})
jsonApi.define('city', { name: '' })
```

JSON:API allows us to modify the relationship between cities at a URL like `/tourists/1/relationships/visited_cities`—[see the docs here](http://jsonapi.org/format/#crud-updating-relationships).

However Devour assumes the relationship is named the same as the model:

```js
jsonApi.one('tourist', 1).relationships().all('visited_cities').patch(...)
// Error: API resource definition for model "visited_cities" not found. Available models: tourist,city
```

This change allows us to specify the name of the relationship in the call to `relationships()`, by checking the previously selected model has a relationship of that name, and adding the correct `model` and `path` to the builder stack:

```js
jsonApi.one('tourist', 1).relationships('visited_cities').patch(...)
// PATCH /tourists/1/relationships/visited_cities
```

This change removes the need to follow with `.all`, however the spec suggests that the path segment following `/relationships` should never have a param following it, so this new implementation makes this explicit and easy. I have preserved the old behaviour of `relationships()` to keep backwards compatibility.

I am very open to alternative solutions on this (in issues I have seen suggested the idea of `.add`ing relationships) but this seems like a fairly clean one.

This fixes #146 and addresses further #46, which was initially completed in #99.

## Testing
List step-by-step how to test the changes.
- [x] Unit tested the URL is built correctly
- [x] Unit tested `patch` and `destroy` work correctly
- [x] Unit tested that the correct errors are thrown
- [x] Tested the above in a console

## Thanks
Thanks for the OSS, we rely on this heavily!