### PR TITLE
Fix handling of camel case notation in relationships and remove cache clearance

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -40,6 +40,10 @@ function collection (items, included, useCache = false) {
 }
 
 function resource (item, included, useCache = false) {
+  console.log('item:', item)
+  console.log('included:', included)
+  console.log('useCache:', useCache)
+
   if (useCache) {
     const cachedItem = cache.get(item.type, item.id)
     if (cachedItem) return cachedItem
@@ -70,6 +74,7 @@ function resource (item, included, useCache = false) {
 
   _forOwn(item.relationships, (value, rel) => {
     var relConfig = model.attributes[rel]
+    var key = rel
 
     if (_isUndefined(relConfig)) {
       rel = rel.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase() })
@@ -82,9 +87,11 @@ function resource (item, included, useCache = false) {
       Logger.warn(`Resource response for type "${item.type}" contains relationship "${rel}", but it is present on model config as a plain attribute.`)
     } else {
       deserializedModel[rel] =
-        attachRelationsFor.call(this, model, relConfig, item, included, rel)
+        attachRelationsFor.call(this, model, relConfig, item, included, key)
     }
   })
+
+  console.log('deserializedModel:', deserializedModel)
 
   var params = ['meta', 'links']
   params.forEach(function (param) {
@@ -100,12 +107,14 @@ function resource (item, included, useCache = false) {
 
 function attachRelationsFor (model, attribute, item, included, key) {
   let relation = null
+  console.log('model:', model, 'attribute:', attribute, 'item:', item, 'included:', included, 'key:', key)
   if (attribute.jsonApi === 'hasOne') {
     relation = attachHasOneFor.call(this, model, attribute, item, included, key)
   }
   if (attribute.jsonApi === 'hasMany') {
     relation = attachHasManyFor.call(this, model, attribute, item, included, key)
   }
+  console.log('relation:', relation)
   return relation
 }
 
@@ -115,6 +124,7 @@ function attachHasOneFor (model, attribute, item, included, key) {
   }
 
   let relatedItems = relatedItemsFor(model, attribute, item, included, key)
+  console.log('relatedItems:', relatedItems)
   if (relatedItems && relatedItems[0]) {
     return resource.call(this, relatedItems[0], included, true)
   } else {

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -40,10 +40,6 @@ function collection (items, included, useCache = false) {
 }
 
 function resource (item, included, useCache = false) {
-  console.log('item:', item)
-  console.log('included:', included)
-  console.log('useCache:', useCache)
-
   if (useCache) {
     const cachedItem = cache.get(item.type, item.id)
     if (cachedItem) return cachedItem
@@ -91,8 +87,6 @@ function resource (item, included, useCache = false) {
     }
   })
 
-  console.log('deserializedModel:', deserializedModel)
-
   var params = ['meta', 'links']
   params.forEach(function (param) {
     if (item[param]) {
@@ -107,14 +101,12 @@ function resource (item, included, useCache = false) {
 
 function attachRelationsFor (model, attribute, item, included, key) {
   let relation = null
-  console.log('model:', model, 'attribute:', attribute, 'item:', item, 'included:', included, 'key:', key)
   if (attribute.jsonApi === 'hasOne') {
     relation = attachHasOneFor.call(this, model, attribute, item, included, key)
   }
   if (attribute.jsonApi === 'hasMany') {
     relation = attachHasManyFor.call(this, model, attribute, item, included, key)
   }
-  console.log('relation:', relation)
   return relation
 }
 
@@ -124,7 +116,6 @@ function attachHasOneFor (model, attribute, item, included, key) {
   }
 
   let relatedItems = relatedItemsFor(model, attribute, item, included, key)
-  console.log('relatedItems:', relatedItems)
   if (relatedItems && relatedItems[0]) {
     return resource.call(this, relatedItems[0], included, true)
   } else {

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -94,8 +94,6 @@ function resource (item, included, useCache = false) {
     }
   })
 
-  cache.clear()
-
   return deserializedModel
 }
 

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -34,9 +34,13 @@ const cache = new class {
 }
 
 function collection (items, included, useCache = false) {
-  return items.map(item => {
+  const collection = items.map(item => {
     return resource.call(this, item, included, useCache)
   })
+
+  cache.clear()
+
+  return collection
 }
 
 function resource (item, included, useCache = false) {


### PR DESCRIPTION
## Priority
Currently not blocking us because we are running on a fork but might hinder others.

## What Changed & Why
This PR contains two changes:

### Allowing to use camelCase notation for relationships

This change is a tad older, so I hope I get the description right.
Currently, multi-worded attributes are automatically converted to camelCase by devour while relationships are kept in kebab-case in case they are defined like this for example:

```
this.jsonApi.define('category',{
  name: '',
  categoryType: '',
  sort: '',
  deleted: '',
  createdAt: '',
  updatedAt: '',
  items:{
    jsonApi: 'hasMany',
    type: 'items'
  },
  'sub-categories':{
    jsonApi: 'hasMany',
    type: 'categories'
  },
  parent:{
    jsonApi: 'hasOne',
    type: 'category'
  }
})
```

This issue can be solved by a middleware, which we did first. But a much simple change is the one included in this PR. More info on the issue can be found here: https://github.com/twg/devour/issues/90

### Removing cache clearance

We observed an issue where a circular dependency in our API responses causes an infinite loop in devour, ending in a `RangeError: Maximum call stack size exceeded`:

```
RangeError: Maximum call stack size exceeded
    at String.replace (<anonymous>)
    at interpolate (pluralize.js:81)
    at pluralize.js:109
    at String.replace (<anonymous>)
    at sanitizeWord (pluralize.js:108)
    at Function.singular (pluralize.js:147)
    at JsonApi.resource (_deserialize.js:64)
    at JsonApi.attachHasOneFor (_deserialize.js:139)
    at JsonApi.attachRelationsFor (_deserialize.js:124)
    at _deserialize.js:105
    at lodash.js:4911
    at baseForOwn (lodash.js:2996)
    at Function.forOwn (lodash.js:13015)
    at JsonApi.resource (_deserialize.js:89)
    at _deserialize.js:50
    at Array.map (<anonymous>)
    at JsonApi.collection (_deserialize.js:49)
    at JsonApi.attachHasManyFor (_deserialize.js:151)
    at JsonApi.attachRelationsFor (_deserialize.js:127)
    at _deserialize.js:105
    at lodash.js:4911
    at baseForOwn (lodash.js:2996)
    at Function.forOwn (lodash.js:13015)
    at JsonApi.resource (_deserialize.js:89)
    at JsonApi.attachHasOneFor (_deserialize.js:139)
    at JsonApi.attachRelationsFor (_deserialize.js:124)
    at _deserialize.js:105
    at lodash.js:4911
    at baseForOwn (lodash.js:2996)
    at Function.forOwn (lodash.js:13015)
    at JsonApi.resource (_deserialize.js:89)
    at _deserialize.js:50
    at Array.map (<anonymous>)
    at JsonApi.collection (_deserialize.js:49)
    at JsonApi.attachHasManyFor (_deserialize.js:151)
    at JsonApi.attachRelationsFor (_deserialize.js:127)
    at _deserialize.js:105
    at lodash.js:4911
    at baseForOwn (lodash.js:2996)
    at Function.forOwn (lodash.js:13015)
    at JsonApi.resource (_deserialize.js:89)
    at JsonApi.attachHasOneFor (_deserialize.js:139)
    at JsonApi.attachRelationsFor (_deserialize.js:124)
    at _deserialize.js:105
    at lodash.js:4911
    at baseForOwn (lodash.js:2996)
    at Function.forOwn (lodash.js:13015)
    at JsonApi.resource (_deserialize.js:89)
    at _deserialize.js:50
    at Array.map (<anonymous>)
```

In our case, this issue occurs because we includes nested objects of nested objects in our requests.

Example:

```
this.jsonApi.define('category',{
  name: '',
  items: {
    jsonApi: 'hasMany',
    type: 'item'
  }
})

this.jsonApi.define('item',{
  name: '',
  thing: {
    jsonApi: 'hasOne',
    type: 'thing'
  }
})

this.jsonApi.define('thing',{
  name: '',
  categories: {
    jsonApi: 'hasMany',
    type: 'category'
  }
})
```

When querying a specific category with the inclusion of `items` and `items.thing `, it throws the error. Interestingly, this issue occurs only in case there are more than 9 `items` belonging to `category`. If there are 9 or fewer `items`, it deserializes as expected.
With 10 or more items in the response, the deserialization is caught in an infinite loop.

We were able to stop the infinite loop by removing the clearing of the cache. However, I am not clear at this time, why the cache is cleared in the first place so I cannot guarantee that the removal of the clearing has no unwanted side-effects.

## Feedback
I was hoping that some of the maintainers have a better understanding of this and can help clarify if the proposed changes are legit or might cause unwanted side-effects.
