### PR TITLE
Deserializer middleware drops relationships from included resources to resources that appear in the main document

### DIFF
--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -26,8 +26,13 @@ module.exports = {
     let links = res.links
     let included = res.included
 
-    if (included) included.push(res.data)
-    else included = [res.data]
+    if (included) {
+      if (Array.isArray(res.data)) {
+        included = included.concat(res.data)
+      } else {
+        included.push(res.data)
+      }
+    } else included = [res.data]
 
     let data = null
 

--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -26,6 +26,9 @@ module.exports = {
     let links = res.links
     let included = res.included
 
+    if (included) included.push(res.data)
+    else included = [res.data]
+
     let data = null
 
     if (status !== 204 && needsDeserialization(req.method)) {


### PR DESCRIPTION
A hack for possibly higher fidelity; with tests.

## Priority
Seems pretty important

## What Changed & Why
main document resources are merged with included resources before deserialization begins

## Testing
See tests
