### PR TITLE
Fix deserialization of kebab case attributes by reverting attr renaming

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -58,8 +58,8 @@ function resource (item, included, useCache = false) {
     var attrConfig = model.attributes[attr]
 
     if (_isUndefined(attrConfig) && attr !== 'id') {
-      const camelCaseAttr = attr.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase() })
-      attrConfig = model.attributes[camelCaseAttr]
+      attr = attr.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase() })
+      attrConfig = model.attributes[attr]
     }
 
     if (_isUndefined(attrConfig) && attr !== 'id') {

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -14,7 +14,7 @@ describe('deserialize', () => {
     jsonApi.define('product', {
       title: '',
       about: '',
-      snakeCaseDescription: ''
+      kebabCaseDescription: ''
     })
     let mockResponse = {
       data: {
@@ -23,7 +23,7 @@ describe('deserialize', () => {
         attributes: {
           'title': 'Some Title',
           'about': 'Some about',
-          'snake-case-description': 'Lorem ipsum'
+          'kebab-case-description': 'Lorem ipsum'
         },
         meta: {
           info: 'Some meta data'
@@ -38,7 +38,7 @@ describe('deserialize', () => {
     expect(product.type).to.eql('products')
     expect(product.title).to.eql('Some Title')
     expect(product.about).to.eql('Some about')
-    expect(product.snakeCaseDescription).to.eql('Lorem ipsum')
+    expect(product.kebabCaseDescription).to.eql('Lorem ipsum')
     expect(product.meta.info).to.eql('Some meta data')
     expect(product.links.arbitrary).to.eql('arbitrary link')
   })

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -13,7 +13,8 @@ describe('deserialize', () => {
   it('should deserialize single resource items', () => {
     jsonApi.define('product', {
       title: '',
-      about: ''
+      about: '',
+      snakeCaseDescription: ''
     })
     let mockResponse = {
       data: {
@@ -21,7 +22,8 @@ describe('deserialize', () => {
         type: 'products',
         attributes: {
           'title': 'Some Title',
-          'about': 'Some about'
+          'about': 'Some about',
+          'snake-case-description': 'Lorem ipsum'
         },
         meta: {
           info: 'Some meta data'
@@ -36,6 +38,7 @@ describe('deserialize', () => {
     expect(product.type).to.eql('products')
     expect(product.title).to.eql('Some Title')
     expect(product.about).to.eql('Some about')
+    expect(product.snakeCaseDescription).to.eql('Lorem ipsum')
     expect(product.meta.info).to.eql('Some meta data')
     expect(product.links.arbitrary).to.eql('arbitrary link')
   })


### PR DESCRIPTION
## Priority
High, the current version is broken for everyone using kebab case notation in API responses (I think).

## What Changed & Why
In a well-intended approach to improve readability, the deserialization of kebab-case attributes was broken in https://github.com/twg/devour/pull/165. This reverts that change and adds a test case.

## Testing
A test case was added to prevent this in the future.