### PR TITLE
Do not print error response's status text when it is empty

### DIFF
--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -28,14 +28,18 @@ function errorKey (index, source) {
 module.exports = {
   name: 'errors',
   error: function (payload) {
+    console.log('---------')
     if (payload.response) {
-      if (payload.response.data) {
-        if (typeof payload.response.data === 'string') {
-          return buildErrors({error: `${payload.response.statusText}: ${payload.response.data}`})
+      const response = payload.response
+      console.dir(response)
+      if (response.data) {
+        if (typeof response.data === 'string') {
+          const error = response.statusText ? `${response.statusText}: ${response.data}` : response.data
+          return buildErrors({ error })
         }
-        return buildErrors(payload.response.data)
+        return buildErrors(response.data)
       }
-      return buildErrors({error: payload.response.statusText})
+      return buildErrors({error: response.statusText})
     }
     if (payload instanceof Error) {
       return payload

--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -28,10 +28,8 @@ function errorKey (index, source) {
 module.exports = {
   name: 'errors',
   error: function (payload) {
-    console.log('---------')
     if (payload.response) {
       const response = payload.response
-      console.dir(response)
       if (response.data) {
         if (typeof response.data === 'string') {
           const error = response.statusText ? `${response.statusText}: ${response.data}` : response.data


### PR DESCRIPTION
## What Changed & Why
Some servers do not return [HTTP Status Text](https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText) in the response. This result in the error message returned as 
': Invalid email or token' instead of 'Unauthorized: Invalid email or token'.
