### PR TITLE
Update es6-promise to allow version 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "devour-client",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3857,9 +3857,9 @@
       }
     },
     "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-set": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "es6-promise": "^3.1.2",
+    "es6-promise": ">=3.1.2 <5.0.0",
     "lodash": "^4.11.2",
     "minilog": "^3.0.0",
     "pluralize": "^1.2.1",


### PR DESCRIPTION
Update es6-promise to allow version 4

The version requirement for es6-promise did not allow using version 4 and up.
Update package.json to allow it and also update the lock file to the
lastest version.

Note: Running npm install also updated the version in package-lock.json,
which was out of date since version 2.0.24.

Fixes #188 
