### PR TITLE
Add custom error builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,19 @@ There are also a few options we can set on the `jsonApi` instance directly. For 
 ```js
 // Append headers to every request
 jsonApi.headers['my-auth-token'] = 'xxxxx-xxxxx'
+
 // Replace the default middleware stack with your own
 jsonApi.middleware = [{...}, {...}, {...}]
+
 // Change the apiUrl
 jsonApi.apiUrl = 'http://api.yoursite.com'
+
+// Use custom error builder
+jsonApi.errorBuilder = (error) => {
+    // add 'meta' in addition to title and detail 
+    const { title, detail, meta } = error
+    return { title, detail, meta }
+}
 ```
 
 ### URL Builder

--- a/src/index.js
+++ b/src/index.js
@@ -38,20 +38,7 @@ const jsonApiHeadersMiddleware = require('./middleware/json-api/req-headers')
 const railsParamsSerializer = require('./middleware/json-api/rails-params-serializer')
 const sendRequestMiddleware = require('./middleware/request')
 const deserializeResponseMiddleware = require('./middleware/json-api/res-deserialize')
-const processErrors = require('./middleware/json-api/res-errors')
-
-let jsonApiMiddleware = [
-  jsonApiHttpBasicAuthMiddleware,
-  jsonApiPostMiddleware,
-  jsonApiPatchMiddleware,
-  jsonApiDeleteMiddleware,
-  jsonApiGetMiddleware,
-  jsonApiHeadersMiddleware,
-  railsParamsSerializer,
-  sendRequestMiddleware,
-  processErrors,
-  deserializeResponseMiddleware
-]
+const errorsMiddleware = require('./middleware/json-api/res-errors')
 
 class JsonApi {
 
@@ -60,6 +47,20 @@ class JsonApi {
       throw new Error('Invalid argument, initialize Devour with an object.')
     }
 
+    const processErrors = errorsMiddleware.getMiddleware(options)
+
+    let jsonApiMiddleware = [
+      jsonApiHttpBasicAuthMiddleware,
+      jsonApiPostMiddleware,
+      jsonApiPatchMiddleware,
+      jsonApiDeleteMiddleware,
+      jsonApiGetMiddleware,
+      jsonApiHeadersMiddleware,
+      railsParamsSerializer,
+      sendRequestMiddleware,
+      processErrors,
+      deserializeResponseMiddleware
+    ]
     let defaults = {
       middleware: jsonApiMiddleware,
       logger: true,

--- a/src/middleware/json-api/res-errors.js
+++ b/src/middleware/json-api/res-errors.js
@@ -1,14 +1,21 @@
 const Logger = require('../../logger')
 
-function buildErrors (serverErrors) {
-  if (!serverErrors) {
-    Logger.error('Unidentified error')
-    return
-  } else {
-    let errors = {}
+function defaultErrorBuilder (error) {
+  const { title, detail } = error
+  return { title, detail }
+}
+
+function getBuildErrors (options) {
+  return function buildErrors (serverErrors) {
+    if (!serverErrors) {
+      Logger.error('Unidentified error')
+      return
+    }
+    const errorBuilder = (options && options.errorBuilder) || defaultErrorBuilder
+    const errors = {}
     if (serverErrors.errors) {
       for (let [index, error] of serverErrors.errors.entries()) {
-        errors[errorKey(index, error.source)] = {title: error.title, detail: error.detail}
+        errors[errorKey(index, error.source)] = errorBuilder(error)
       }
     }
     if (serverErrors.error) {
@@ -25,23 +32,26 @@ function errorKey (index, source) {
   return source.pointer.split('/').pop()
 }
 
-module.exports = {
-  name: 'errors',
-  error: function (payload) {
-    if (payload.response) {
-      const response = payload.response
-      if (response.data) {
-        if (typeof response.data === 'string') {
-          const error = response.statusText ? `${response.statusText}: ${response.data}` : response.data
-          return buildErrors({ error })
+exports.getMiddleware = function (options) {
+  const buildErrors = getBuildErrors(options)
+  return {
+    name: 'errors',
+    error: function (payload) {
+      if (payload.response) {
+        const response = payload.response
+        if (response.data) {
+          if (typeof response.data === 'string') {
+            const error = response.statusText ? `${response.statusText}: ${response.data}` : response.data
+            return buildErrors({error})
+          }
+          return buildErrors(response.data)
         }
-        return buildErrors(response.data)
+        return buildErrors({error: response.statusText})
       }
-      return buildErrors({error: response.statusText})
+      if (payload instanceof Error) {
+        return payload
+      }
+      return null
     }
-    if (payload instanceof Error) {
-      return payload
-    }
-    return null
   }
 }

--- a/test/api/configuration-test.js
+++ b/test/api/configuration-test.js
@@ -1,0 +1,89 @@
+/* global describe, it, beforeEach, afterEach */
+
+import JsonApi from '../../src/index'
+import mockError from '../helpers/mock-error'
+import expect from 'expect.js'
+
+describe('Custom Error Builder', () => {
+  var jsonApi = null
+  beforeEach(() => {
+    jsonApi = new JsonApi({
+      apiUrl: 'http://myapi.com',
+      errorBuilder: (error) => {
+        const {title, detail, meta} = error
+        return {
+          customTitle: `Custom title: ${title}`,
+          customDetail: `Custom detail: ${detail}`,
+          meta
+        }
+      }
+    })
+
+    // mock errors
+    mockError(jsonApi, {
+      data: {
+        data: [{
+          id: '1',
+          type: 'products',
+          attributes: {
+            title: 'Some Title'
+          }
+        }]
+      }
+    },
+      [
+        {
+          status: 422,
+          source: {pointer: '/data/attributes/first-name'},
+          title: 'Invalid Attribute',
+          detail: 'First name must contain at least three characters.',
+          meta: {
+            created: '2019-07-15T13:23:21.177Z',
+            author: 'user@example.com'
+          }
+        }
+      ])
+
+    // define model
+    jsonApi.define('product', {
+      title: ''
+    })
+  })
+
+  afterEach(() => {
+    jsonApi.resetBuilder()
+  })
+
+  it('should fail by mocked errors', (done) => {
+    try {
+      expect(jsonApi.findAll).withArgs('product').to.throwException()
+    } finally {
+      done()
+    }
+  })
+
+  it('should include custom errors on response objects', (done) => {
+    jsonApi.findAll('product')
+      .then(() => {
+        done(new Error('Expected method to reject'))
+      })
+      .catch((error) => {
+        expect(error).to.be.defined
+        expect(error).to.be.an('object')
+        error = error['first-name']
+        expect(error).to.be.defined
+        expect(error).to.be.an('object')
+        expect(error.title).not.to.be.defined
+        expect(error.details).not.to.be.defined
+        expect(error.customTitle).to.be.a('string')
+        expect(error.customTitle).to.equal('Custom title: Invalid Attribute')
+        expect(error.customDetail).to.be.a('string')
+        expect(error.customDetail).to.equal('Custom detail: First name must contain at least three characters.')
+        expect(error.meta).to.be.a('object')
+        expect(error.meta.created).to.equal('2019-07-15T13:23:21.177Z')
+        expect(error.meta.author).to.equal('user@example.com')
+
+        done()
+      })
+  })
+})

--- a/test/helpers/mock-error.js
+++ b/test/helpers/mock-error.js
@@ -1,0 +1,20 @@
+export default function (jsonApi, res = {}, errors = null) {
+  let mockResponse = {
+    name: 'mock-error',
+    req: (payload) => {
+      payload.req.adapter = function () {
+        return Promise.reject(res)
+      }
+      return payload
+    },
+    error: () => {
+      return { response: { data: { errors } } }
+    }
+  }
+  // if we already mocked something replace it
+  if (jsonApi.middleware[0].name === mockResponse.name) {
+    jsonApi.middleware[0] = mockResponse
+  } else {
+    jsonApi.middleware.unshift(mockResponse)
+  }
+}


### PR DESCRIPTION
## Priority
Low

## What Changed & Why
I added a new functionality to be able to override the default error object returned by _devour-client_. I encountered a use case in which I needed to pass the _meta_ attribute from the server's error to the frontend (to display some extra data with the error). I noticed that the library builds an object with _title_ and _detail_ fields, and figured one might want to customize this.

## Testing
Added unit-tests for this. See `test/api/configuration-test.js`

## Bug/Ticket Tracker
N/A

## Documentation
Updated `README.md` accordingly.
