### PR TITLE
Do not serialize undefined attributes

### DIFF
--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -26,18 +26,14 @@ function resource (modelName, item) {
     }
     if (isRelationship(value)) {
       serializeRelationship(key, item[key], value, serializedRelationships)
-    } else {
+    } else if (item[key] !== undefined) {
       serializedAttributes[key] = item[key]
     }
   })
 
   serializedResource.type = typeName
 
-  var attrValues = Object.keys(serializedAttributes).map(key => {
-    return serializedAttributes[key]
-  })
-
-  if (Boolean(attrValues) && attrValues.filter(val => val === undefined).length !== attrValues.length) {
+  if (Object.keys(serializedAttributes).length > 0) {
     serializedResource.attributes = serializedAttributes
   }
 


### PR DESCRIPTION
## Priority
Low

## What Changed & Why
- Prevent undefined attributes from being serialized in the request
- Prevent the attributes object attribute from being serialized if empty

## Testing
Added two unit-tests. See code.

## Bug/Ticket Tracker
https://github.com/twg/devour/issues/141
