### PR TITLE
Middleware naming convention.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,28 +29,28 @@ const Logger = require('./logger')
  *   standards.
  *
  */
-const jsonApiHttpBasicAuthMiddleware = require('./middleware/json-api/req-http-basic-auth')
-const jsonApiPostMiddleware = require('./middleware/json-api/req-post')
-const jsonApiPatchMiddleware = require('./middleware/json-api/req-patch')
-const jsonApiDeleteMiddleware = require('./middleware/json-api/req-delete')
-const jsonApiGetMiddleware = require('./middleware/json-api/req-get')
-const jsonApiHeadersMiddleware = require('./middleware/json-api/req-headers')
-const railsParamsSerializer = require('./middleware/json-api/rails-params-serializer')
-const sendRequestMiddleware = require('./middleware/request')
-const deserializeResponseMiddleware = require('./middleware/json-api/res-deserialize')
-const processErrors = require('./middleware/json-api/res-errors')
+const httpBasicAuthMiddleware = require('./middleware/json-api/req-http-basic-auth')
+const postMiddleware = require('./middleware/json-api/req-post')
+const patchMiddleware = require('./middleware/json-api/req-patch')
+const deleteMiddleware = require('./middleware/json-api/req-delete')
+const getMiddleware = require('./middleware/json-api/req-get')
+const headersMiddleware = require('./middleware/json-api/req-headers')
+const railsParamsSerializerMiddleware = require('./middleware/json-api/req-rails-params-serializer')
+const sendAxiosRequestMiddleware = require('./middleware/req-axios-request')
+const deserializeMiddleware = require('./middleware/json-api/res-deserialize')
+const processErrors = require('./middleware/json-api/res-process-errors')
 
 let jsonApiMiddleware = [
-  jsonApiHttpBasicAuthMiddleware,
-  jsonApiPostMiddleware,
-  jsonApiPatchMiddleware,
-  jsonApiDeleteMiddleware,
-  jsonApiGetMiddleware,
-  jsonApiHeadersMiddleware,
-  railsParamsSerializer,
-  sendRequestMiddleware,
-  processErrors,
-  deserializeResponseMiddleware
+  httpBasicAuthMiddleware,
+  postMiddleware,
+  patchMiddleware,
+  deleteMiddleware,
+  getMiddleware,
+  headersMiddleware,
+  railsParamsSerializerMiddleware,
+  sendAxiosRequestMiddleware,
+  deserializeMiddleware,
+  processErrors
 ]
 
 class JsonApi {

--- a/src/middleware/json-api/req-rails-params-serializer.js
+++ b/src/middleware/json-api/req-rails-params-serializer.js
@@ -1,7 +1,7 @@
 const Qs = require('qs')
 
 module.exports = {
-  name: 'rails-params-serializer',
+  name: 'RAILS_PARAMS_SERIALIZER',
   req: (payload) => {
     if (payload.req.method === 'GET') {
       payload.req.paramsSerializer = function (params) {

--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -10,7 +10,7 @@ function isCollection (responseData) {
 }
 
 module.exports = {
-  name: 'response',
+  name: 'DESERIALIZE',
   res: function (payload) {
     /*
      *   Note: The axios ajax response attaches the actual response data to

--- a/src/middleware/json-api/res-process-errors.js
+++ b/src/middleware/json-api/res-process-errors.js
@@ -26,7 +26,7 @@ function errorKey (index, source) {
 }
 
 module.exports = {
-  name: 'errors',
+  name: 'PROCESS_ERRORS',
   error: function (payload) {
     if (payload.response) {
       const response = payload.response

--- a/src/middleware/req-axios-request.js
+++ b/src/middleware/req-axios-request.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'axios-request',
+  name: 'AXIOS_REQUEST',
   req: function (payload) {
     let jsonApi = payload.jsonApi
     return jsonApi.axios(payload.req)

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -1,8 +1,8 @@
 /* global describe, context, it, beforeEach, afterEach */
 
 import JsonApi from '../../src/index'
-import jsonApiGetMiddleware from '../../src/middleware/json-api/req-get'
-import jsonApiDeleteMiddleware from '../../src/middleware/json-api/req-delete'
+import getMiddleware from '../../src/middleware/json-api/req-get'
+import deleteMiddleware from '../../src/middleware/json-api/req-delete'
 import mockResponse from '../helpers/mock-response'
 import expect from 'expect.js'
 import sinon from 'sinon'
@@ -705,7 +705,7 @@ describe('JsonApi', () => {
         }
       }
 
-      jsonApi.middleware = [jsonApiGetMiddleware, inspectorMiddleware]
+      jsonApi.middleware = [getMiddleware, inspectorMiddleware]
 
       jsonApi.one('foo', 1).find().then(() => done()).catch(() => done())
     })
@@ -721,7 +721,7 @@ describe('JsonApi', () => {
         }
       }
 
-      jsonApi.middleware = [jsonApiDeleteMiddleware, inspectorMiddleware]
+      jsonApi.middleware = [deleteMiddleware, inspectorMiddleware]
 
       jsonApi.destroy('foo', 1).then(() => done()).catch(() => done())
     })
@@ -738,7 +738,7 @@ describe('JsonApi', () => {
         }
       }
 
-      jsonApi.middleware = [jsonApiDeleteMiddleware, inspectorMiddleware]
+      jsonApi.middleware = [deleteMiddleware, inspectorMiddleware]
 
       const payload = [
         {type: 'bar', id: 2},
@@ -762,7 +762,7 @@ describe('JsonApi', () => {
         }
       }
 
-      jsonApi.middleware = [jsonApiDeleteMiddleware, inspectorMiddleware]
+      jsonApi.middleware = [deleteMiddleware, inspectorMiddleware]
 
       const payload = [
         {type: 'bar', id: 2},
@@ -788,7 +788,7 @@ describe('JsonApi', () => {
         }
       }
 
-      jsonApi.middleware = [jsonApiDeleteMiddleware, inspectorMiddleware]
+      jsonApi.middleware = [deleteMiddleware, inspectorMiddleware]
 
       const payload = [
         {type: 'bar', id: 2},


### PR DESCRIPTION
This is a breaking change, as it might break existing code that uses
`insertMiddlewareBefore` and `insertMiddlewareAfter`, so this PR should be merge in next major 

## Priority
Low

## What Changed & Why
Tried to unify middleware names and file names.
