### PR TITLE
Update lodash to 4.17.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5514,9 +5514,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "es6-promise": ">=3.1.2 <5.0.0",
-    "lodash": "^4.11.2",
+    "lodash": "^4.17.15",
     "minilog": "^3.0.0",
     "pluralize": "^1.2.1",
     "qs": "^6.1.0"


### PR DESCRIPTION
## Priority
High

## What Changed & Why

lodash dependency updated to >= 4.17.13 (4.17.15 specifically) to include patch for security advisory CVE-2019-10744.

## Testing
List step-by-step how to test the changes.
- npm install
- npm test

## Bug/Ticket Tracker
Fixes #197

## Documentation
See lodash [patch for CVE-2019-10744](https://github.com/lodash/lodash/pull/4336)