### PR TITLE
Ability to easily set bearer token and removing middlewares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 .idea
 lib/
+.vscode

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Devour takes an object as the initializer. The following options are available:
 
 **auth**: An object with username and password, used to pass in HTTP Basic Authentication Headers, `new JsonApi({apiUrl: 'http://your-api-here.com', auth: {username: 'secret', password: 'cheesecake'})`
 
+**bearer**: A string containing the bearer token, used to add a HTTP Authorization Header `new JsonApi({apiUrl: 'http://your-api-here.com', bearer: 'your-token-here'})
+
 **trailingSlash**: An optional object to use trailing slashes on resource and/or collection urls (defaults to false), `new JsonApi({apiUrl: 'http://your-api-here.com', trailingSlash: {resource: false, collection: true})`
 
 ### Relationships
@@ -155,6 +157,7 @@ let errorMiddleware = {
 jsonApi.insertMiddlewareBefore('axios-request', requestMiddleware)
 jsonApi.insertMiddlewareAfter('response', responseMiddleware)
 jsonApi.replaceMiddleware('errors', errorMiddleware)
+jsonApi.removeMiddleware('response')
 ```
 
 #### The payload object

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "lib/",
   "scripts": {
     "prepublish": "npm run compile",
+    "prepublish-windows": "npm run compile:windows",
     "publish": "git push origin && git push origin --tags",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
     "compile": "rm -rf lib/ && babel -d lib/ src/",
+    "compile:windows": "rd /s /q \"lib/\" && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "autofix": "standard --fix",
     "test": "standard && mocha"

--- a/src/middleware/json-api/req-bearer.js
+++ b/src/middleware/json-api/req-bearer.js
@@ -1,0 +1,12 @@
+const _isNil = require('lodash/isNil')
+const _assign = require('lodash/assign')
+
+module.exports = {
+  name: 'add-bearer-token',
+  req: payload => {
+    if (!_isNil(payload.jsonApi.bearer)) {
+      payload.req.headers = _assign({}, payload.req.headers, {'Authorization': 'Bearer ' + payload.jsonApi.bearer})
+    }
+    return payload
+  }
+}

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -106,7 +106,7 @@ describe('JsonApi', () => {
       jsonApi = new JsonApi({apiUrl: 'http://myapi.com', bearer: 'abc'})
       jsonApi.define('foo', {title: ''})
 
-      let inspectorMiddleware = {
+      const inspectorMiddleware = {
         name: 'inspector-middleware',
         req: (payload) => {
           expect(payload.req.headers.Authorization).to.be.eql('Bearer abc')
@@ -120,11 +120,11 @@ describe('JsonApi', () => {
       jsonApi.one('foo', 1).get().then(() => done())
     })
 
-    it('should not add HTPP Authorization header if not set', (done) => {
+    it('should not add HTPP Authorization header if not set and from the moment when set it should be added', (done) => {
       jsonApi = new JsonApi({apiUrl: 'http://myapi.com'})
       jsonApi.define('foo', {title: ''})
 
-      let inspectorMiddleware = {
+      const inspectorMiddleware = {
         name: 'inspector-middleware',
         req: (payload) => {
           expect(payload.req.headers).to.be.eql(undefined)
@@ -135,7 +135,20 @@ describe('JsonApi', () => {
 
       jsonApi.middleware = [bearerTokenMiddleware, inspectorMiddleware]
 
-      jsonApi.one('foo', 1).get().then(() => done())
+      const inspectorMiddlewareBearer = {
+        name: 'inspector-middleware-bearer',
+        req: (payload) => {
+          expect(payload.req.headers.Authorization).to.be.eql('Bearer abc')
+          return {}
+        }
+      }
+
+      jsonApi.one('foo', 1).get().then(() => {
+        jsonApi.bearer = 'abc'
+        jsonApi.middleware = [bearerTokenMiddleware, inspectorMiddlewareBearer]
+
+        jsonApi.one('foo', 2).get().then(() => done())
+      })
     })
 
     describe('Pluralize options', () => {


### PR DESCRIPTION
## Priority
Low

## What Changed & Why
Added in the following function:
- removeMiddleware in order to remove a middleware

Changes made to the following function:
- insertMiddleware to avoid the same middleware being added twice

Added in the following option for the constructor:
- bearer to set the Bearer Authorization token to be added in requests

Added the following middleware:
- add-bearer-token to set the Bearer Authorization token to requests

## Testing
Unit tests have been written in order to verify the changes are working
