### PR TITLE
Serialize meta object into resource identifiers in relationship object

### DIFF
--- a/src/middleware/json-api/_serialize.js
+++ b/src/middleware/json-api/_serialize.js
@@ -75,7 +75,7 @@ function serializeRelationship (relationshipName, relationship, relationshipType
 function serializeHasMany (relationships, type) {
   return {
     data: _map(relationships, (item) => {
-      return {id: item.id, type: type || item.type}
+      return {id: item.id, type: type || item.type, meta: item.meta}
     })
   }
 }
@@ -85,7 +85,7 @@ function serializeHasOne (relationship, type) {
     return {data: null}
   }
   return {
-    data: {id: relationship.id, type: type || relationship.type}
+    data: {id: relationship.id, type: type || relationship.type, meta: relationship.meta}
   }
 }
 

--- a/test/api/serialize-test.js
+++ b/test/api/serialize-test.js
@@ -300,4 +300,36 @@ describe('serialize', () => {
     expect(serializedItem.relationships.payables.data[1].id).to.eql(4)
     expect(serializedItem.relationships.payables.data[1].type).to.eql('tax')
   })
+
+  it('should serialize meta on hasOne relationship if present', () => {
+    jsonApi.define('product', {
+      title: '',
+      category: {
+        jsonApi: 'hasOne',
+        type: 'categories'
+      }
+    })
+    let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello', category: {
+      id: 4,
+      type: 'categories',
+      meta: {customStuff: 'More custom stuff'}
+    }})
+    expect(serializedItem.relationships.category.data.meta.customStuff).to.eql('More custom stuff')
+  })
+
+  it('should serialize meta on hasMany relationship if present', () => {
+    jsonApi.define('product', {
+      title: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tags'
+      }
+    })
+    let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello', tags: [{
+      id: 4,
+      type: 'tags',
+      meta: {customStuff: 'More custom stuff'}}
+    ]})
+    expect(serializedItem.relationships.tags.data[0].meta.customStuff).to.eql('More custom stuff')
+  })
 })


### PR DESCRIPTION
## Priority
High

## Screenshot
N/A

## What Changed & Why
The meta object is now serialised for resource identifier objects in relationships.
The JSON:API specification says: A “resource identifier object” MAY also include a meta member, whose value is a meta object that contains non-standard meta-information. https://jsonapi.org/format/#document-resource-identifier-objects

This change allows to send meta information in relationship resource identifier objects as defined in the spec.

## Testing
Unit tests were added.

## Documentation
https://jsonapi.org/format/#document-resource-identifier-objects