### PR TITLE
Fix the verification for replacing middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -279,8 +279,13 @@ class JsonApi {
   }
 
   replaceMiddleware (middlewareName, newMiddleware) {
-    if (!this.middlewareExists(newMiddleware.name)) {
-      Logger.error('The middleware ' + newMiddleware.name + ' does not exists')
+    if (!this.middlewareExists(middlewareName)) {
+      Logger.error('The middleware ' + middlewareName + ' does not exist')
+      return
+    }
+
+    if (this.middlewareExists(newMiddleware.name)) {
+      Logger.error('The middleware ' + newMiddleware.name + ' already exists')
       return
     }
 
@@ -290,7 +295,7 @@ class JsonApi {
 
   removeMiddleware (middlewareName) {
     if (!this.middlewareExists(middlewareName)) {
-      Logger.error('The middleware ' + middlewareName + ' does not exists')
+      Logger.error('The middleware ' + middlewareName + ' does not exist')
       return
     }
 


### PR DESCRIPTION
This fixes #203 .

## Priority

The verification code makes it impossible to replace middleware (unless it has the exact same name).

## What Changed & Why

The code checked the existance of the new middleware while it should be checking the existance of the previous middleware that will be replaced. I also added verification to check that we don't include the same code twice and fixed a grammar mistake.

## Testing

The code below will fail without these changes; it won't fail with them.

```javascript
let errorMiddleware = {
  name: 'only-status',
  error: function (payload) {
    return { status: payload.response.status }
  }
}
jsonApi.replaceMiddleware('errors', errorMiddleware)
```

## Bug/Ticket Tracker

#203