### PR TITLE
Add model to req object returned by get method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,9 +168,12 @@ class JsonApi {
   }
 
   get (params = {}) {
+    let lastRequest = _last(this.builderStack)
+
     let req = {
       method: 'GET',
       url: this.urlFor(),
+      model: _get(lastRequest, 'model'),
       data: {},
       params
     }

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -1309,6 +1309,7 @@ describe('JsonApi', () => {
         req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos')
+          expect(payload.req.model).to.be.eql('foo')
           return {}
         }
       }
@@ -1324,6 +1325,7 @@ describe('JsonApi', () => {
         req: (payload) => {
           expect(payload.req.method).to.be.eql('GET')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
+          expect(payload.req.model).to.be.eql('foo')
           return {}
         }
       }

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -1342,6 +1342,7 @@ describe('JsonApi', () => {
           expect(payload.req.method).to.be.eql('POST')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos')
           expect(payload.req.data).to.be.eql({title: 'foo'})
+          expect(payload.req.model).to.be.eql('foo')
           return {}
         }
       }
@@ -1358,6 +1359,7 @@ describe('JsonApi', () => {
           expect(payload.req.method).to.be.eql('POST')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars')
           expect(payload.req.data).to.be.eql({title: 'foo'})
+          expect(payload.req.model).to.be.eql('bar')
           return {}
         }
       }
@@ -1374,6 +1376,7 @@ describe('JsonApi', () => {
           expect(payload.req.method).to.be.eql('PATCH')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
           expect(payload.req.data).to.be.eql({title: 'bar'})
+          expect(payload.req.model).to.be.eql('foo')
           return {}
         }
       }
@@ -1390,6 +1393,7 @@ describe('JsonApi', () => {
           expect(payload.req.method).to.be.eql('PATCH')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars')
           expect(payload.req.data).to.be.eql({title: 'bar'})
+          expect(payload.req.model).to.be.eql('bar')
           return {}
         }
       }
@@ -1405,6 +1409,7 @@ describe('JsonApi', () => {
         req: (payload) => {
           expect(payload.req.method).to.be.eql('DELETE')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1')
+          expect(payload.req.model).to.be.eql('foo')
           return {}
         }
       }
@@ -1419,6 +1424,7 @@ describe('JsonApi', () => {
         req: (payload) => {
           expect(payload.req.method).to.be.eql('DELETE')
           expect(payload.req.url).to.be.eql('http://myapi.com/foos/1/bars/2')
+          expect(payload.req.model).to.be.eql('bar')
           return {}
         }
       }


### PR DESCRIPTION
## What Changed & Why

Adds model to the request object returned by the `get` method to bring it line with other methods.

Also adds tests that confirm correct model is added to other methods.

## Bug/Ticket Tracker

https://github.com/twg/devour/issues/216


