### PR TITLE
Keep type and id of non included relations

### DIFF
--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -120,9 +120,9 @@ function attachHasOneFor (model, attribute, item, included, key) {
     return resource.call(this, relatedItems[0], included, true)
   }
 
-  const relatedId = _get(item.relationships, [key, 'data', 'id'], false)
-  if (relatedId) {
-    return relatedId
+  const relationshipData = _get(item.relationships, [key, 'data'], false)
+  if (relationshipData) {
+    return relationshipData
   }
   return null
 }
@@ -131,14 +131,15 @@ function attachHasManyFor (model, attribute, item, included, key) {
   if (!item.relationships) {
     return null
   }
+
   let relatedItems = relatedItemsFor(model, attribute, item, included, key)
   if (relatedItems && relatedItems.length > 0) {
     return collection.call(this, relatedItems, included, true)
   }
 
-  const relatedIds = _get(item.relationships, [key, 'data'], false)
-  if (relatedIds) {
-    return _map(relatedIds, relatedItem => relatedItem.id)
+  const relationshipData = _get(item.relationships, [key, 'data'], false)
+  if (relationshipData) {
+    return relationshipData
   }
 
   return []

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -374,7 +374,7 @@ describe('deserialize', () => {
     expect(product.tags[1].name).to.eql('two')
   })
 
-  it('should deserialize ids of related resources that are not included', () => {
+  it('should deserialize types and ids of related resources that are not included', () => {
     jsonApi.define('product', {
       title: '',
       tags: {
@@ -406,7 +406,14 @@ describe('deserialize', () => {
     expect(product.id).to.eql('1')
     expect(product.title).to.eql('hello')
     expect(product.tags).to.be.an('array')
-    expect(product.tags[0]).to.eql('5')
-    expect(product.tags[1]).to.eql('6')
+    expect(product.tags.length).to.be(2)
+
+    expect(product.tags[0]).to.be.an('object')
+    expect(product.tags[0].id).to.eql('5')
+    expect(product.tags[0].type).to.eql('tags')
+
+    expect(product.tags[1]).to.be.an('object')
+    expect(product.tags[1].id).to.eql('6')
+    expect(product.tags[1].type).to.eql('tags')
   })
 })


### PR DESCRIPTION
## Priority
> Is this PR blocking your next action?
It is [blocking](https://github.com/twg/devour/pull/153#issuecomment-764777410) @unicrus.

## What Changed & Why

Return type and id for non-included relations instead of just the id. The id alone is most probably not valid data and having the type and id is incredibly useful for fetching more information from an API.

This is, of course, a breaking change.

## People
Mention people who would be interested in the changeset: @unicrus & @JaZo
Engineer(s) who wrote the old version: @graemetait
