### PR TITLE
Add note about uniqueness of middleware name

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Devour uses a fully middleware based approach. This allows you to easily manipul
 
 ### Your First Middleware
 
-Adding your own middleware is easy. It's just a simple JavaScript object that has a `name`, `req`, and/or `res` property. The `req` or `res` property is a function that receives a `payload`, which houses all the details of the request cycle _(see documentation below)_. For async operations, your `req` or `res` methods can return a promise, which will need to resolve before the middleware chain continues. Otherwise, you may just manipulate the `payload` as needed and return it immediately.
+Adding your own middleware is easy. It's just a simple JavaScript object that has a `name`, `req`, and/or `res` property. The `name` property must be the unique name of your middleware. The `req` or `res` property is a function that receives a `payload`, which houses all the details of the request cycle _(see documentation below)_. For async operations, your `req` or `res` methods can return a promise, which will need to resolve before the middleware chain continues. Otherwise, you may just manipulate the `payload` as needed and return it immediately.
 
 ```js
 let requestMiddleware = {


### PR DESCRIPTION
## What Changed & Why
I added a note to the documentation about the requirement that the name of a middleware should be unique.

## Bug/Ticket Tracker
#206 introduced an issue in our implementation because we were replacing default middleware with a patched version using the same name. This resulted in a "The middleware errors already exists" error. But the requirement of a middleware having an unique name is nowhere to be found in the documentation.