### PR TITLE
Expose the whole document too

### DIFF
--- a/src/middleware/json-api/res-deserialize.js
+++ b/src/middleware/json-api/res-deserialize.js
@@ -46,6 +46,6 @@ module.exports = {
       })
     }
 
-    return { data, errors, meta, links }
+    return { data, errors, meta, links, document: res }
   }
 }


### PR DESCRIPTION
## What Changed & Why

In JSON:API the server responds with data structure called [a document](https://jsonapi.org/format/#document-structure). Devour-client will process it for us; it combines attributes and relationships etc. to obtain resources that are very easy to handle. However Devour will omit certain things in the deserialisation process. URLs in relationships for example. In most cases you don't need these, but if you do, there's really no way to obtain them and you're stuck.

This PR exposes the whole document as it was returned by the server to allow for a way around the deserialisation process.
