### PR TITLE
Throw an Error if id is nil

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const axios = require('axios')
 const pluralize = require('pluralize')
 // Import only what we use from lodash.
 const _isUndefined = require('lodash/isUndefined')
+const _isNil = require('lodash/isNil')
 const _isString = require('lodash/isString')
 const _isPlainObject = require('lodash/isPlainObject')
 const _isArray = require('lodash/isArray')
@@ -439,6 +440,9 @@ class JsonApi {
   }
 
   resourcePathFor (modelName, id) {
+    if (_isNil(id)) {
+      throw new Error(`No ID specified; id is '${id}'`)
+    }
     const collectionPath = this.collectionPathFor(modelName)
     return `${collectionPath}/${encodeURIComponent(id)}`
   }

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -247,6 +247,30 @@ describe('JsonApi', () => {
         expect(jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1')
       })
 
+      it('should refuse to constuct single resource urls for models containing `null`', () => {
+        jsonApi.define('product', {})
+        expect(function () {
+          jsonApi.resourceUrlFor('product', null)
+        }).to.throwException(/^No ID specified/)
+      })
+
+      it('should construct single resource urls for models with the string "null"', () => {
+        jsonApi.define('product', {})
+        expect(jsonApi.resourceUrlFor('product', 'null')).to.eql('http://myapi.com/products/null')
+      })
+
+      it('should refuse to constuct single resource urls for models containing `undefined`', () => {
+        jsonApi.define('product', {})
+        expect(function () {
+          jsonApi.resourceUrlFor('product', undefined)
+        }).to.throwException(/^No ID specified/)
+      })
+
+      it('should construct single resource urls for models with the string "undefined"', () => {
+        jsonApi.define('product', {})
+        expect(jsonApi.resourceUrlFor('product', 'undefined')).to.eql('http://myapi.com/products/undefined')
+      })
+
       it('should allow urlFor to be called with various options', () => {
         expect(jsonApi.urlFor({ model: 'foo', id: 1 })).to.eql('http://myapi.com/foos/1')
         expect(jsonApi.urlFor({ model: 'foo' })).to.eql('http://myapi.com/foos')

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -247,7 +247,7 @@ describe('JsonApi', () => {
         expect(jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1')
       })
 
-      it('should refuse to constuct single resource urls for models containing `null`', () => {
+      it('should refuse to construct single resource urls for models containing `null`', () => {
         jsonApi.define('product', {})
         expect(function () {
           jsonApi.resourceUrlFor('product', null)
@@ -259,7 +259,7 @@ describe('JsonApi', () => {
         expect(jsonApi.resourceUrlFor('product', 'null')).to.eql('http://myapi.com/products/null')
       })
 
-      it('should refuse to constuct single resource urls for models containing `undefined`', () => {
+      it('should refuse to construct single resource urls for models containing `undefined`', () => {
         jsonApi.define('product', {})
         expect(function () {
           jsonApi.resourceUrlFor('product', undefined)


### PR DESCRIPTION
## What Changed & Why

Fail fast if the caller tries to use `null` or `undefined` as the id.
Nothing good will come of it so you'd better know about it as soon as
possible.

Note that it's still possible to use the strings "null" or "undefined"
as the id which will construct the URLs you'd expect it to.

## Testing

Automated tests have been added.
