### PR TITLE
Resolves #263 added a means to disable attaching relationship metadata on unresolved includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ let { data, errors, meta, links } = jsonApi.findAll('post', {include: 'comments'
 // => data.comment will be populated with any comments included by your API
 ```
 
+By default, Devour will include relationship metadata (id, type, and other metadata) in each response. It may be handy to exclude this metadata from the response when the relationship is not resolved by the backend (not listed in the "includes" Json:api response). For this, make sure the `attachRelationshipDataOnUnresolvedIncludes` client flag is set to `false`, (default value is `true`).
+
 ### Flexibility
 
 Devour uses a fully middleware based approach. This allows you to easily manipulate any part of the request and response cycle by injecting your own middleware. In fact, it's entirely possible to fully remove our default middleware and write your own. Moving forward we hope to see adapters for different server implementations. If you'd like to take a closer look at the middleware layer, please checkout:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ let { data, errors, meta, links } = jsonApi.findAll('post', {include: 'comments'
 // => data.comment will be populated with any comments included by your API
 ```
 
-By default, Devour will include relationship metadata (id, type, and other metadata) in each response. It may be handy to exclude this metadata from the response when the relationship is not resolved by the backend (not listed in the "includes" Json:api response). For this, make sure the `attachRelationshipDataOnUnresolvedIncludes` client flag is set to `false`, (default value is `true`).
+By default, Devour will include relationship metadata (id, type, and other metadata) in each response. It may be handy to exclude this metadata from the response when the relationship is not resolved by the backend (not listed in the "includes" JSON:API response). For this, make sure the `attachRelationshipDataOnUnresolvedIncludes` client flag is set to `false`, (default value is `true`).
 
 ### Flexibility
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,8 @@ class JsonApi {
       auth: {},
       bearer: null,
       trailingSlash: { collection: false, resource: false },
-      disableErrorsForMissingResourceDefinitions: false
+      disableErrorsForMissingResourceDefinitions: false,
+      attachRelationshipDataOnUnresolvedIncludes: true
     }
 
     const deprecatedConstructors = (args) => {
@@ -95,6 +96,7 @@ class JsonApi {
     this.apiUrl = options.apiUrl
     this.bearer = options.bearer
     this.disableErrorsForMissingResourceDefinitions = options.disableErrorsForMissingResourceDefinitions
+    this.attachRelationshipDataOnUnresolvedIncludes = options.attachRelationshipDataOnUnresolvedIncludes
     this.models = {}
     this.deserialize = deserialize
     this.serialize = serialize

--- a/src/middleware/json-api/_deserialize.js
+++ b/src/middleware/json-api/_deserialize.js
@@ -120,10 +120,13 @@ function attachHasOneFor (model, attribute, item, included, key) {
     return resource.call(this, relatedItems[0], included, true)
   }
 
-  const relationshipData = _get(item.relationships, [key, 'data'], false)
-  if (relationshipData) {
-    return relationshipData
+  if (this.attachRelationshipDataOnUnresolvedIncludes) {
+    const relationshipData = _get(item.relationships, [key, 'data'], false)
+    if (relationshipData) {
+      return relationshipData
+    }
   }
+
   return null
 }
 
@@ -137,9 +140,11 @@ function attachHasManyFor (model, attribute, item, included, key) {
     return collection.call(this, relatedItems, included, true)
   }
 
-  const relationshipData = _get(item.relationships, [key, 'data'], false)
-  if (relationshipData) {
-    return relationshipData
+  if (this.attachRelationshipDataOnUnresolvedIncludes) {
+    const relationshipData = _get(item.relationships, [key, 'data'], false)
+    if (relationshipData) {
+      return relationshipData
+    }
   }
 
   return []

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -426,4 +426,81 @@ describe('deserialize', () => {
     expect(product.tags[1].id).to.eql('6')
     expect(product.tags[1].type).to.eql('tags')
   })
+
+  it('should not include relationship data on unresolved hasMany relationships if attachRelationshipDataOnUnresolvedIncludes flag is set to false', () => {
+    jsonApi = new JsonApi({
+      apiUrl: 'http://myapi.com',
+      attachRelationshipDataOnUnresolvedIncludes: false
+    })
+    jsonApi.define('product', {
+      title: '',
+      tags: {
+        jsonApi: 'hasMany',
+        type: 'tag'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+    const mockResponse = {
+      data: {
+        id: '1',
+        type: 'products',
+        attributes: {
+          title: 'hello'
+        },
+        relationships: {
+          tags: {
+            data: [
+              { id: '5', type: 'tags' },
+              { id: '6', type: 'tags' }
+            ]
+          }
+        }
+      }
+    }
+    const product = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
+    expect(product.id).to.eql('1')
+    expect(product.type).to.eql('products')
+    expect(product.title).to.eql('hello')
+    expect(product.tags).to.be.an('array')
+    expect(product.tags).to.be.empty()
+  })
+
+  it('should not include relationship data on unresolved hasOne relationships if attachRelationshipDataOnUnresolvedIncludes flag is set to false', () => {
+    jsonApi = new JsonApi({
+      apiUrl: 'http://myapi.com',
+      attachRelationshipDataOnUnresolvedIncludes: false
+    })
+    jsonApi.define('product', {
+      title: '',
+      tag: {
+        jsonApi: 'hasOne',
+        type: 'tag'
+      }
+    })
+    jsonApi.define('tag', {
+      name: ''
+    })
+    const mockResponse = {
+      data: {
+        id: '1',
+        type: 'products',
+        attributes: {
+          title: 'hello'
+        },
+        relationships: {
+          tag: {
+            data: { id: '5', type: 'tag' }
+          }
+        }
+      }
+    }
+    const product = deserialize.resource.call(jsonApi, mockResponse.data, mockResponse.included)
+    expect(product.id).to.eql('1')
+    expect(product.type).to.eql('products')
+    expect(product.title).to.eql('hello')
+    expect(product.tag).to.not.be.an('array')
+    expect(product.tag).to.eql(null)
+  })
 })

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -464,7 +464,7 @@ describe('deserialize', () => {
     expect(product.type).to.eql('products')
     expect(product.title).to.eql('hello')
     expect(product.tags).to.be.an('array')
-    expect(product.tags).to.be.empty()
+    expect(product.tags.length).to.be(0)
   })
 
   it('should not include relationship data on unresolved hasOne relationships if attachRelationshipDataOnUnresolvedIncludes flag is set to false', () => {


### PR DESCRIPTION
## Screenshot
N/A

## What Changed & Why

Learn more at #263 

Introduced a flag `attachRelationshipDataOnUnresolvedIncludes` which by default is set to **true** for backwards-compatibility purposes.

When set to **true**, Devour will continue to attach relationship metadata in the client's response on unresolved includes as it normally does.

When set to **false** however, Devour will abstain from attaching such metatada. This applies both for relationships of type `hasMany` and `hasOne`-

## Testing

Just run the tests.

## Documentation

Updated the README file with instructions.
